### PR TITLE
Refactoring version into software_info

### DIFF
--- a/Inc/software_info.h
+++ b/Inc/software_info.h
@@ -32,13 +32,13 @@
  *
  ****************************************************************************/
 
-#ifndef INC_VERSION_H_
-#define INC_VERSION_H_
+#ifndef INC_SOFTWARE_INFO_H_
+#define INC_SOFTWARE_INFO_H_
 
 #include <stdint.h>
 #include <stdbool.h>
 
-bool Version_getDataJson(uint8_t* buffer, uint16_t size);
-bool Version_getData(uint8_t* buffer, uint16_t size);
+bool SwInfo_getDataJson(uint8_t* buffer, uint16_t size);
+bool SwInfo_getVersion(uint8_t* buffer, uint16_t size);
 
-#endif /* INC_VERSION_H_ */
+#endif /* INC_SOFTWARE_INFO_H_ */

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ SRC_FILES1=\
   Src/base64.c \
   Src/crc32.c \
   Src/json.c \
+  Src/software_info.c \
   Src/utils.c \
-  Src/version.c \
   Tests/test_main.c \
   Tests/test_crc32.c \
   Tests/test_base64.c

--- a/Src/software_info.c
+++ b/Src/software_info.c
@@ -33,8 +33,8 @@
  ****************************************************************************/
 
 #include <string.h>
-#include "version.h"
 #include "json.h"
+#include "software_info.h"
 
 #define GIT_BRANCH_SIZE 40
 #define GIT_HASH_SIZE   42
@@ -54,25 +54,31 @@ static const char git_tag[GIT_TAG_SIZE] = GIT_TAG;
  * {
 *   "git_branch":"master",
 *   "git_hash":"be387ad0b2ba6dc0877e8e255e872ee310a9127c",
-*   "git_tag":"v1.1.0"
+*   "git_tag":"v1.1.0",
+*   "ld_script_variant":"FLASH"
 *  }
 */
 
 bool
-Version_getDataJson(uint8_t* buffer, uint16_t size) {
+SwInfo_getDataJson(uint8_t* buffer, uint16_t size) {
 
     bool success = true;
     success &= Json_startString((char*)buffer, size);
     success &= Json_addData((char*)buffer, size, "git_branch", git_branch);
     success &= Json_addData((char*)buffer, size, "git_hash", git_hash);
     success &= Json_addData((char*)buffer, size, "git_tag", git_tag);
+#ifdef LDS_RAM_VERSION
+    success &= Json_addData((char*)buffer, size, "ld_script_variant", "RAM");
+#else
+    success &= Json_addData((char*)buffer, size, "ld_script_variant", "FLASH");
+#endif
     success &= Json_endString((char*)buffer, size);
 
     return success;
 }
 
 bool
-Version_getData(uint8_t* buffer, uint16_t size) {
+SwInfo_getVersion(uint8_t* buffer, uint16_t size) {
 
     bool success = false;
     uint16_t str_size = strlen(BRANCH_NAME_STR) + strlen(COMMIT_HASH_STR) + strlen(LAST_TAG_STR);


### PR DESCRIPTION
Repurposing version into software info since it is a more general name.
With the bootloader's new feature to run the software directly into RAM, it is helpful to know where is current software running. 
For this, it is added JSON value "ld_script_variant" that is determined in build time as FLASH or RAM. 

Since we didn't create any version release since JSON was introduced into the project it is safe to change the command string from "**version_json**" to "**software_info_json**"