### PR TITLE
Improved ECL configurations.

### DIFF
--- a/ECLAIR/analysis.ecl
+++ b/ECLAIR/analysis.ecl
@@ -12,7 +12,4 @@
 
 -eval_file=config.ecl
 
--doc="Test suite should not be analyzed."
--file_tag+={external,"^Tests/.*$"}
-
--reports={hide,all_exp_external}
+-reports+={hide,all_exp_external}

--- a/ECLAIR/config.ecl
+++ b/ECLAIR/config.ecl
@@ -1,21 +1,12 @@
--enable=MC3R1.D4.4
--enable=MC3.R1.1
--enable=MC3R1.R10.1
--enable=MC3R1.R10.4
+-enable=MC3R1
 
-#-eval_file=gcc-x86_64-7.5.0.ecl
+-doc="Sources in the test suite are not under MISRA compliance."
+-file_tag+={external,"^Tests/.*$"}
 
-#-config=MC3R1.D4.9,macros+={hide, ^REFLECT_DATA$}
-#-config=MC3R1.D4.9,macros+={hide, ^REFLECT_REMAINDER$}
+-comment_selector={cppcheck_suppress_comment, "^// cppcheck-suppress.*$"}
 
-#-file_tag+={api:public,"^src/crc\\.h$"}
-#-public_files+=api:public
-#-config=MC3R1.R8.7,+declarations={hide,"^reflect\\(.*$"}
+-doc="cppcheck deviation comments should not be considered."
+-config=MC3R1.D4.4,+ignored_comments="cppcheck_suppress_comment"
 
-#-config=MC3R1.R15.5,reports+={hide,"all_area(context(^main\\(.*$))"}
-
-#-config=MC3R1.R21.6,reports+={hide,"all_area(all_loc(^src/main\\.c$))"}
-
--default_call_properties+="pointee_read(1..=never)"
--default_call_properties+="pointee_write(1..=always)"
--default_call_properties+="taken()"
+-doc="For documentation reasons, URLs in comments are allowed to contain //."
+-config=MC3R1.R3.1,comments={url_in_comment,"!^.*(/\*|[^:]//).*$" }


### PR DESCRIPTION
Enabled all guidelines of MISRA C:2012 Revision 1.
Added deviations of Rule 3.1 for:
- cppcheck-suppress comments;
- HTTP links.