### PR TITLE
Fix queue capacity and some misra violations

### DIFF
--- a/Inc/base64.h
+++ b/Inc/base64.h
@@ -6,6 +6,6 @@
 #include <string.h>
 
 int Base64_encode(const char* data, size_t data_length, char* result, size_t max_result_length);
-int Base64_decode(const char* in, size_t in_len, unsigned char* out, size_t max_out_len);
+int Base64_decode(const char* in, size_t in_len, uint8_t* out, size_t max_out_len);
 
 #endif /* UTILITY_BASE64_H_ */

--- a/Inc/priority_queue.h
+++ b/Inc/priority_queue.h
@@ -44,13 +44,13 @@ typedef struct {
 
 typedef struct {
     unsigned int size;
-    unsigned int capacity;
+    uint32_t capacity;
     unsigned int element_size;
     unsigned int* priority_array;
     uint8_t* buffer;
 } PriorityQueue_t;
 
-void PriorityQueue_initQueue(PriorityQueue_t* const queue, const int capacity, const unsigned int element_size, const PriorityQueueItem_t* items);
+bool PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const unsigned int element_size, const PriorityQueueItem_t* items);
 bool PriorityQueue_isEmpty(const PriorityQueue_t* const queue);
 bool PriorityQueue_enqueue(PriorityQueue_t* const queue, const PriorityQueueItem_t* const item);
 bool PriorityQueue_dequeue(PriorityQueue_t* const queue, void* const element);

--- a/Inc/queue.h
+++ b/Inc/queue.h
@@ -39,14 +39,14 @@
 
 typedef struct {
     unsigned int front;
-    int rear;
+    uint32_t rear;
     unsigned int size;
-    unsigned int capacity;
+    uint32_t capacity;
     unsigned int element_size;
     uint8_t* buffer;
 } Queue_t;
 
-void Queue_initQueue(Queue_t* const queue, const int capacity, const unsigned int element_size, uint8_t* buffer);
+bool Queue_initQueue(Queue_t* const queue, const uint32_t capacity, const unsigned int element_size, uint8_t* buffer);
 bool Queue_isFull(const Queue_t* const queue);
 bool Queue_isEmpty(const Queue_t* const queue);
 bool Queue_enqueue(Queue_t* const queue, const void* const element);

--- a/Inc/utils.h
+++ b/Inc/utils.h
@@ -37,7 +37,7 @@
 
 #include "typedefs.h"
 
-uint32_t Utils_StringToUint32(const unsigned char* buf, const uint32_t lenght);
+uint32_t Utils_StringToUint32(const char* buf, const uint32_t lenght);
 void Utils_SwapElements(uint8_t* first, uint8_t* second, const uint32_t size);
 
 // Big-endian

--- a/Src/base64.c
+++ b/Src/base64.c
@@ -41,7 +41,7 @@ Base64_encode(const char* data, size_t data_length, char* result, size_t max_res
         (unsigned char)'\0'
     };
     unsigned char* out;
-    unsigned char* pos;
+    uint8_t* pos;
     const uint8_t* in = (const uint8_t*) data;
 
     size_t len = 4U * ((data_length + 2U) / 3U);
@@ -87,7 +87,7 @@ Base64_encode(const char* data, size_t data_length, char* result, size_t max_res
                 if ((data_length - in_position) == 1U) {
                     *pos = base64_table[(in[0] & 0x03U) << 4];
                     ++pos;
-                    *pos = '=';
+                    *pos = (uint8_t)'=';
                     ++pos;
                 } else {
                     *pos = base64_table[((in[0] & 0x03U) << 4) | (in[1] >> 4)];
@@ -95,19 +95,19 @@ Base64_encode(const char* data, size_t data_length, char* result, size_t max_res
                     *pos = base64_table[(in[1] & 0x0FU) << 2];
                     ++pos;
                 }
-                *pos = '=';
+                *pos = (uint8_t)'=';
                 ++pos;
             }
         }
 
-        *pos = '\0';
+        *pos = (uint8_t)'\0';
     }
 
     return success;
 }
 
 int
-Base64_decode(const char* in, size_t in_len, unsigned char* out, size_t max_out_len) {
+Base64_decode(const char* in, size_t in_len, uint8_t* out, size_t max_out_len) {
     int success = 0;
     const uint32_t base64_index[256] = {
         0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
@@ -141,25 +141,25 @@ Base64_decode(const char* in, size_t in_len, unsigned char* out, size_t max_out_
     if (success == 0) {
         size_t j = 0U;
         for (size_t i = 0U; i < len; i += 4U) {
-            unsigned int n = (base64_index[in_data_uchar[i]] << 18U) | (base64_index[in_data_uchar[i + 1U]] << 12U) |
-                             (base64_index[in_data_uchar[i + 2U]] << 6U) | (base64_index[in_data_uchar[i + 3U]]);
-            out[j] = n >> 16U;
+            uint32_t n = (base64_index[in_data_uchar[i]] << 18U) | (base64_index[in_data_uchar[i + 1U]] << 12U) |
+                         (base64_index[in_data_uchar[i + 2U]] << 6U) | (base64_index[in_data_uchar[i + 3U]]);
+            out[j] = (uint8_t)(n >> 16U);
             ++j;
-            out[j] = (n >> 8U) & 0xFFU;
+            out[j] = (uint8_t)((n >> 8U) & 0xFFU);
             ++j;
-            out[j] = n & 0xFFU;
+            out[j] = (uint8_t)(n & 0xFFU);
             ++j;
         }
         if (pad_bool) {
-            unsigned int n = (base64_index[in_data_uchar[len]] << 18U) | (base64_index[in_data_uchar[len + 1U]] << 12U);
-            out[out_len - 1U] = n >> 16U;
+            uint32_t n = (base64_index[in_data_uchar[len]] << 18U) | (base64_index[in_data_uchar[len + 1U]] << 12U);
+            out[out_len - 1U] = (uint8_t)(n >> 16U);
 
             if ((in_len > (len + 2U)) && (in_data_uchar[len + 2U] != (unsigned char)'=')) {
                 if ((out_len + 1U) > max_out_len) {
                     success = 1;
                 } else {
                     n |= base64_index[in_data_uchar[len + 2U]] << 6U;
-                    out[out_len] = (n >> 8U) & 0xFFU;
+                    out[out_len] = (uint8_t)((n >> 8U) & 0xFFU);
                 }
             }
         }

--- a/Src/crc32.c
+++ b/Src/crc32.c
@@ -34,6 +34,9 @@
 
 #include "crc32.h"
 
+#define REFLECTED_INPUT_BITS_NUM    (8U)
+#define REFLECTED_OUTPUT_BITS_NUM   (32U)
+
 static uint32_t Reflect(uint32_t data, uint8_t n_bits);
 
 uint32_t
@@ -87,7 +90,7 @@ CalculateCRC32(
 
     for (counter = 0u; counter < crc_length; ++counter) {
         if (reflected_input) {
-            temp = Reflect(*temp_data_ptr, 8u);
+            temp = (uint8_t)Reflect(*temp_data_ptr, REFLECTED_INPUT_BITS_NUM);
         } else {
             temp = *temp_data_ptr;
         }
@@ -98,7 +101,7 @@ CalculateCRC32(
     }
 
     if (reflected_output) {
-        crc = Reflect(crc, sizeof(uint32_t) * 8u);
+        crc = Reflect(crc, REFLECTED_OUTPUT_BITS_NUM);
     }
 
     if (final_xor) {
@@ -127,6 +130,6 @@ Reflect(uint32_t data, uint8_t n_bits) {
         temp_data = (temp_data >> 1u);
     }
 
-    return (reflection);
+    return reflection;
 
 }   /* reflect() */

--- a/Src/json.c
+++ b/Src/json.c
@@ -106,7 +106,7 @@ bool
 Json_findByKey(const char* buffer, size_t buffer_size, const char* key, char* value, size_t max_value_size) {
     bool success = false;
 
-    uint32_t max_search_size = buffer_size - strlen(key);
+    uint32_t max_search_size = (uint32_t)(buffer_size - strlen(key));
 
     uint32_t index;
     size_t key_size = strlen(key);
@@ -126,7 +126,7 @@ Json_findByKey(const char* buffer, size_t buffer_size, const char* key, char* va
     if (success) {
 
         success = false;
-        for (index = index + key_size + 1u; index < buffer_size; ++index) {
+        for (index += (uint32_t)(key_size + 1U); index < buffer_size; ++index) {
 
             if (buffer[index] == '"') {
                 break;

--- a/Src/priority_queue.c
+++ b/Src/priority_queue.c
@@ -73,13 +73,18 @@ FindLowestPriorityIndex(const PriorityQueue_t* const queue) {
     return index;
 }
 
-void
-PriorityQueue_initQueue(PriorityQueue_t* const queue, const int capacity, const unsigned int element_size, const PriorityQueueItem_t* items) {
-    queue->capacity = capacity;
-    queue->size = 0U;
-    queue->element_size = element_size;
-    queue->priority_array = items->priority;
-    queue->buffer = items->element;
+bool
+PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const unsigned int element_size, const PriorityQueueItem_t* items) {
+    bool status = false;
+    if (capacity != 0U) {
+        queue->capacity = capacity;
+        queue->size = 0U;
+        queue->element_size = element_size;
+        queue->priority_array = items->priority;
+        queue->buffer = items->element;
+        status = true;
+    }
+    return status;
 }
 
 bool

--- a/Src/queue.c
+++ b/Src/queue.c
@@ -36,14 +36,19 @@
 
 #include <string.h>
 
-void
-Queue_initQueue(Queue_t* const queue, const int capacity, const unsigned int element_size, uint8_t* buffer) {
-    queue->capacity = capacity;
-    queue->front = 0U;
-    queue->size = 0U;
-    queue->rear = capacity - 1;
-    queue->element_size = element_size;
-    queue->buffer = buffer;
+bool
+Queue_initQueue(Queue_t* const queue, const uint32_t capacity, const unsigned int element_size, uint8_t* buffer) {
+    bool status = false;
+    if (capacity != 0U) {
+        queue->capacity = capacity;
+        queue->front = 0U;
+        queue->size = 0U;
+        queue->rear = capacity - 1U;
+        queue->element_size = element_size;
+        queue->buffer = buffer;
+        status = true;
+    }
+    return status;
 }
 
 bool
@@ -60,9 +65,9 @@ bool
 Queue_enqueue(Queue_t* const queue, const void* const element) {
     bool status = false;
     if (!Queue_isFull(queue)) {
-        queue->rear = (queue->rear + 1) % (int)queue->capacity;
+        queue->rear = (queue->rear + 1U) % queue->capacity;
         uint8_t* buffer = queue->buffer;
-        if (memcpy(&buffer[queue->rear * (int)queue->element_size], element, queue->element_size) != NULL_PTR) {
+        if (memcpy(&buffer[queue->rear * queue->element_size], element, queue->element_size) != NULL_PTR) {
             queue->size = queue->size + 1U;
             status = true;
         }
@@ -101,7 +106,7 @@ Queue_rear(const Queue_t* const queue, void* const element) {
     bool status = false;
     if (!Queue_isEmpty(queue)) {
         const uint8_t* buffer = (const uint8_t*)queue->buffer;
-        if (memcpy(element, &buffer[queue->rear * (int)queue->element_size], queue->element_size) != NULL_PTR) {
+        if (memcpy(element, &buffer[queue->rear * queue->element_size], queue->element_size) != NULL_PTR) {
             status = true;
         }
     }

--- a/Src/utils.c
+++ b/Src/utils.c
@@ -37,12 +37,14 @@
 #include <math.h>
 
 uint32_t
-Utils_StringToUint32(const unsigned char* buf, const uint32_t lenght) {
+Utils_StringToUint32(const char* buf, const uint32_t lenght) {
     uint32_t integer = 0U;
     uint32_t i = 0U;
 
-    while ((buf[i] != (unsigned char)'\0') && (lenght > i)) {
-        integer += (uint32_t)(buf[i] - (unsigned char)'0') * (uint32_t)pow(10.0, (lenght - (i + 1U)));
+    while ((buf[i] != '\0') && (lenght > i)) {
+        const uint32_t unsigned_power = lenght - (i + 1U);
+        const int32_t number = buf[i] - '0';
+        integer += (uint32_t)(number) * (uint32_t)pow(10.0, (float32_t)(unsigned_power));
         ++i;
     }
     return integer;
@@ -73,25 +75,25 @@ Utils_Serialize32BE(uint8_t* buf, uint32_t value) {
     buf[0] = (uint8_t)(value >> 24u) & 0xFFu;
     buf[1] = (uint8_t)(value >> 16u) & 0xFFu;
     buf[2] = (uint8_t)(value >> 8u) & 0xFFu;
-    buf[3] = (uint8_t)(value >> 0u) & 0xFFu;
+    buf[3] = (uint8_t)(value) & 0xFFu;
 }
 
 void
 Utils_Serialize24BE(uint8_t* buf, uint32_t value) {
     buf[0] = (uint8_t)(value >> 16u) & 0xFFu;
     buf[1] = (uint8_t)(value >> 8u) & 0xFFu;
-    buf[2] = (uint8_t)(value >> 0u) & 0xFFu;
+    buf[2] = (uint8_t)(value) & 0xFFu;
 }
 
 void
 Utils_Serialize16BE(uint8_t* buf, uint16_t value) {
     buf[0] = (uint8_t)(value >> 8u) & 0xFFu;
-    buf[1] = (uint8_t)(value >> 0u) & 0xFFu;
+    buf[1] = (uint8_t)(value) & 0xFFu;
 }
 
 void
 Utils_Serialize8BE(uint8_t* buf, uint8_t value) {
-    buf[0] = (uint8_t)(value >> 0u) & 0xFFu;
+    buf[0] = (uint8_t)(value) & 0xFFu;
 }
 
 void
@@ -124,16 +126,16 @@ Utils_Deserialize32BE(const uint8_t* buf, uint32_t* value) {
     *value = (uint32_t)(buf[0] << 24u);
     *value |= (uint32_t)(buf[1] << 16u);
     *value |= (uint32_t)(buf[2] << 8u);
-    *value |= (uint32_t)(buf[3] << 0u);
+    *value |= (uint32_t)buf[3];
 }
 
 void
 Utils_Deserialize16BE(const uint8_t* buf, uint16_t* value) {
-    *value = (uint32_t)(buf[0] << 8u);
-    *value |= (uint32_t)(buf[1] << 0u);
+    *value = (uint16_t)(buf[0] << 8U);
+    *value |= (uint16_t)buf[1];
 }
 
 void
 Utils_Deserialize8BE(const uint8_t* buf, uint8_t* value) {
-    *value = (uint32_t)(buf[0] << 0u);
+    *value = buf[0];
 }

--- a/Tests/test_base64.c
+++ b/Tests/test_base64.c
@@ -1,4 +1,5 @@
 #include "base64.h"
+
 #include "unity.h"
 #include "unity_fixture.h"
 
@@ -50,7 +51,7 @@ TEST(Base64, Base64_decode) {
     {
         char text[] = "IMProject is a very cool project!";
         char base64[] = "SU1Qcm9qZWN0IGlzIGEgdmVyeSBjb29sIHByb2plY3Qh";
-        unsigned char string[200];
+        uint8_t string[200];
         int success = Base64_decode(base64, strlen(base64), string, sizeof(string));
         TEST_ASSERT_EQUAL_MEMORY(text, string, strlen(text));
         TEST_ASSERT_EQUAL_INT(0, success);
@@ -58,14 +59,14 @@ TEST(Base64, Base64_decode) {
     {
         // Output size is too big
         char base64[] = "SU1Qcm9qZWN0IGlzIGEgdmVyeSBjb29sIHByb2plY3Qh";
-        unsigned char string[10];
+        uint8_t string[10];
         int success = Base64_decode(base64, strlen(base64), string, sizeof(string));
         TEST_ASSERT_EQUAL_INT(1, success);
     }
     {
         char text[] = "B?E(H+MbQeThWmZq4t7w!z%C*F)J@NcR";
         char base64[] = "Qj9FKEgrTWJRZVRoV21acTR0N3cheiVDKkYpSkBOY1I=";
-        unsigned char string[200];
+        uint8_t string[200];
         int success = Base64_decode(base64, strlen(base64), string, sizeof(string));
         TEST_ASSERT_EQUAL_MEMORY(text, string, strlen(text));
         TEST_ASSERT_EQUAL_INT(0, success);
@@ -73,7 +74,7 @@ TEST(Base64, Base64_decode) {
     {
         // Output size is too big
         char base64[] = "Qj9FKEgrTWJRZVRoV21acTR0N3cheiVDKkYpSkBOY1I=";
-        unsigned char string[31];
+        uint8_t string[31];
         int success = Base64_decode(base64, strlen(base64), string, sizeof(string));
         TEST_ASSERT_EQUAL_INT(1, success);
     }

--- a/Tests/test_priority_queue.c
+++ b/Tests/test_priority_queue.c
@@ -13,7 +13,8 @@ TEST_TEAR_DOWN(PriorityQueue) {
 
 TEST_GROUP_RUNNER(PriorityQueue) {
     RUN_TEST_CASE(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32);
-    RUN_TEST_CASE(PriorityQueue, PriorityQueue_enqueue_dequeue_float);
+    RUN_TEST_CASE(PriorityQueue, PriorityQueue_enqueue_dequeue_float32_t);
+    RUN_TEST_CASE(PriorityQueue, PriorityQueue_no_capacity);
 }
 
 TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32) {
@@ -22,9 +23,9 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32) {
     PriorityQueueItem_t items;
     items.element = (uint8_t*)buffer;
     items.priority = priority_array;
-    const unsigned int capacity = sizeof(buffer) / sizeof(buffer[0]);
+    const uint32_t capacity = sizeof(buffer) / sizeof(buffer[0]);
     PriorityQueue_t queue;
-    PriorityQueue_initQueue(&queue, capacity, sizeof(buffer[0]), &items);
+    TEST_ASSERT_TRUE(PriorityQueue_initQueue(&queue, capacity, sizeof(buffer[0]), &items));
 
     TEST_ASSERT_TRUE(PriorityQueue_isEmpty(&queue));
     uint32_t element;
@@ -59,18 +60,18 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32) {
     TEST_ASSERT_EQUAL_UINT32(50U, element);
 }
 
-TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_float) {
-    float buffer[100];
+TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_float32_t) {
+    float32_t buffer[100];
     unsigned int priority_array[100];
     PriorityQueueItem_t items;
     items.element = (uint8_t*)buffer;
     items.priority = priority_array;
-    const unsigned int capacity = sizeof(buffer) / sizeof(buffer[0]);
+    const uint32_t capacity = sizeof(buffer) / sizeof(buffer[0]);
     PriorityQueue_t queue;
-    PriorityQueue_initQueue(&queue, capacity, sizeof(buffer[0]), &items);
+    TEST_ASSERT_TRUE(PriorityQueue_initQueue(&queue, capacity, sizeof(buffer[0]), &items));
 
     TEST_ASSERT_TRUE(PriorityQueue_isEmpty(&queue));
-    float element;
+    float32_t element;
     TEST_ASSERT_FALSE(PriorityQueue_dequeue(&queue, &element));
 
     // fill the queue
@@ -102,4 +103,11 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_float) {
     TEST_ASSERT_EQUAL_FLOAT(100.0F, element);
     TEST_ASSERT_TRUE(PriorityQueue_dequeue(&queue, &element));
     TEST_ASSERT_EQUAL_FLOAT(50.0F, element);
+}
+
+TEST(PriorityQueue, PriorityQueue_no_capacity) {
+    float64_t buffer[100];
+    PriorityQueueItem_t items;
+    PriorityQueue_t queue;
+    TEST_ASSERT_FALSE(PriorityQueue_initQueue(&queue, 0U, sizeof(buffer[0]), &items));
 }

--- a/Tests/test_queue.c
+++ b/Tests/test_queue.c
@@ -13,14 +13,15 @@ TEST_TEAR_DOWN(Queue) {
 
 TEST_GROUP_RUNNER(Queue) {
     RUN_TEST_CASE(Queue, Queue_enqueue_dequeue_uint32);
-    RUN_TEST_CASE(Queue, Queue_enqueue_dequeue_float);
+    RUN_TEST_CASE(Queue, Queue_enqueue_dequeue_float32_t);
+    RUN_TEST_CASE(Queue, Queue_no_capacity);
 }
 
 TEST(Queue, Queue_enqueue_dequeue_uint32) {
     uint32_t array[100];
-    const unsigned int capacity = sizeof(array) / sizeof(array[0]);
+    const uint32_t capacity = sizeof(array) / sizeof(array[0]);
     Queue_t queue;
-    Queue_initQueue(&queue, capacity, sizeof(array[0]), (uint8_t*)array);
+    TEST_ASSERT_TRUE(Queue_initQueue(&queue, capacity, sizeof(array[0]), (uint8_t*)array));
 
     TEST_ASSERT_FALSE(Queue_isFull(&queue));
     TEST_ASSERT_TRUE(Queue_isEmpty(&queue));
@@ -55,21 +56,21 @@ TEST(Queue, Queue_enqueue_dequeue_uint32) {
     TEST_ASSERT_EQUAL_UINT32(i, element);
 }
 
-TEST(Queue, Queue_enqueue_dequeue_float) {
-    float array[100];
-    const unsigned int capacity = sizeof(array) / sizeof(array[0]);
+TEST(Queue, Queue_enqueue_dequeue_float32_t) {
+    float32_t array[100];
+    const uint32_t capacity = sizeof(array) / sizeof(array[0]);
     Queue_t queue;
-    Queue_initQueue(&queue, capacity, sizeof(array[0]), (uint8_t*)array);
+    TEST_ASSERT_TRUE(Queue_initQueue(&queue, capacity, sizeof(array[0]), (uint8_t*)array));
 
     TEST_ASSERT_FALSE(Queue_isFull(&queue));
     TEST_ASSERT_TRUE(Queue_isEmpty(&queue));
-    float element = 1.0f;
+    float32_t element = 1.0F;
     TEST_ASSERT_FALSE(Queue_dequeue(&queue, &element));
 
     // fill the queue
     uint32_t i;
     for (i = 0U; i < capacity; ++i) {
-        float element_temp = (float)i + 1.1f;
+        float32_t element_temp = (float32_t)i + 1.1F;
         TEST_ASSERT_TRUE(Queue_enqueue(&queue, &element_temp));
     }
 
@@ -79,20 +80,26 @@ TEST(Queue, Queue_enqueue_dequeue_float) {
 
     // check front element
     TEST_ASSERT_TRUE(Queue_front(&queue, &element));
-    TEST_ASSERT_EQUAL_FLOAT(1.1f, element);
+    TEST_ASSERT_EQUAL_FLOAT(1.1F, element);
 
     // check rear element
     TEST_ASSERT_TRUE(Queue_rear(&queue, &element));
-    TEST_ASSERT_EQUAL_FLOAT((float)capacity - 1.0f + 1.1f, element);
+    TEST_ASSERT_EQUAL_FLOAT((float32_t)capacity - 1.0F + 1.1F, element);
 
     // dequeue
     TEST_ASSERT_TRUE(Queue_dequeue(&queue, &element));
-    TEST_ASSERT_EQUAL_FLOAT(1.1f, element);
+    TEST_ASSERT_EQUAL_FLOAT(1.1F, element);
 
     // enqueue
-    element = 5.1f;
+    element = 5.1F;
     TEST_ASSERT_TRUE(Queue_enqueue(&queue, &element));
-    float test_element;
+    float32_t test_element;
     TEST_ASSERT_TRUE(Queue_rear(&queue, &test_element));
     TEST_ASSERT_EQUAL_FLOAT(test_element, element);
+}
+
+TEST(Queue, Queue_no_capacity) {
+    float128_t array[100];
+    Queue_t queue;
+    TEST_ASSERT_FALSE(Queue_initQueue(&queue, 0U, sizeof(array[0]), (uint8_t*)array));
 }

--- a/Tests/test_utils.c
+++ b/Tests/test_utils.c
@@ -1,10 +1,11 @@
 #include "utils.h"
+
 #include "unity.h"
 #include "unity_fixture.h"
 
 TEST_GROUP(Utils);
 
-uint8_t test_data_1[] = {
+static const uint8_t test_data_1[] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
     0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29,
@@ -30,9 +31,9 @@ TEST_GROUP_RUNNER(Utils) {
 }
 
 TEST(Utils, Utils_StringToUint32) {
-    TEST_ASSERT_EQUAL_UINT32(Utils_StringToUint32((unsigned char*)"39", 2U), 39U);
-    TEST_ASSERT_EQUAL_UINT32(Utils_StringToUint32((unsigned char*)"0", 1U), 0U);
-    TEST_ASSERT_EQUAL_UINT32(Utils_StringToUint32((unsigned char*)"2165217", 7U), 2165217U);
+    TEST_ASSERT_EQUAL_UINT32(Utils_StringToUint32("39", 2U), 39U);
+    TEST_ASSERT_EQUAL_UINT32(Utils_StringToUint32("0", 1U), 0U);
+    TEST_ASSERT_EQUAL_UINT32(Utils_StringToUint32("2165217", 7U), 2165217U);
 }
 
 TEST(Utils, Utils_SwapElements) {


### PR DESCRIPTION
- in case of queue initialization, check capacity, if capacity is 0 then it is not possible to add new element in queue, so initialization function should return false in that case
- change type of rear in queue, it has to be positive number so it should be unsigned instead of signed
- add new unit tests to check behavior in case of capacity 0

- Fix violations of MISRA rule 10.3 - The value of an expression shall not be assigned to an object with a narrower essential type or of a different essential type category.