### PR TITLE
utils: Fix violations of MISRA rules (10.8, 12.2)

### DIFF
--- a/Src/utils.c
+++ b/Src/utils.c
@@ -123,15 +123,15 @@ Utils_DeserializeBlobLE(const uint8_t* buf, uint8_t* dst, uint32_t size) {
 
 void
 Utils_Deserialize32BE(const uint8_t* buf, uint32_t* value) {
-    *value = (uint32_t)(buf[0] << 24u);
-    *value |= (uint32_t)(buf[1] << 16u);
-    *value |= (uint32_t)(buf[2] << 8u);
+    *value = (uint32_t)buf[0] << 24u;
+    *value |= (uint32_t)buf[1] << 16u;
+    *value |= (uint32_t)buf[2] << 8u;
     *value |= (uint32_t)buf[3];
 }
 
 void
 Utils_Deserialize16BE(const uint8_t* buf, uint16_t* value) {
-    *value = (uint16_t)(buf[0] << 8U);
+    *value = (uint16_t)buf[0] << 8U;
     *value |= (uint16_t)buf[1];
 }
 


### PR DESCRIPTION
10.8 - The value of a composite expression shall not be cast to a different essential type category or a wider essential type
12.2 - The right hand operand of a shift operator shall lie in the range zero to one less than the width in bits of the essential type of the left hand operand
