### PR TITLE
Fix MISRA violations (14.2, 21.15)

### DIFF
--- a/Inc/priority_queue.h
+++ b/Inc/priority_queue.h
@@ -53,6 +53,6 @@ typedef struct {
 bool PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const unsigned int element_size, const PriorityQueueItem_t* items);
 bool PriorityQueue_isEmpty(const PriorityQueue_t* const queue);
 bool PriorityQueue_enqueue(PriorityQueue_t* const queue, const PriorityQueueItem_t* const item);
-bool PriorityQueue_dequeue(PriorityQueue_t* const queue, void* const element);
+bool PriorityQueue_dequeue(PriorityQueue_t* const queue, uint8_t* const element);
 
 #endif /* UTILITY_PRIORITY_QUEUE_H_ */

--- a/Inc/priority_queue.h
+++ b/Inc/priority_queue.h
@@ -43,7 +43,7 @@ typedef struct {
 } PriorityQueueItem_t;
 
 typedef struct {
-    unsigned int size;
+    uint32_t size;
     uint32_t capacity;
     unsigned int element_size;
     unsigned int* priority_array;

--- a/Inc/queue.h
+++ b/Inc/queue.h
@@ -49,9 +49,9 @@ typedef struct {
 bool Queue_initQueue(Queue_t* const queue, const uint32_t capacity, const unsigned int element_size, uint8_t* buffer);
 bool Queue_isFull(const Queue_t* const queue);
 bool Queue_isEmpty(const Queue_t* const queue);
-bool Queue_enqueue(Queue_t* const queue, const void* const element);
-bool Queue_dequeue(Queue_t* const queue, void* const element);
-bool Queue_front(const Queue_t* const queue, void* const element);
-bool Queue_rear(const Queue_t* const queue, void* const element);
+bool Queue_enqueue(Queue_t* const queue, const uint8_t* const element);
+bool Queue_dequeue(Queue_t* const queue, uint8_t* const element);
+bool Queue_front(const Queue_t* const queue, uint8_t* const element);
+bool Queue_rear(const Queue_t* const queue, uint8_t* const element);
 
 #endif /* UTILITY_QUEUE_H_ */

--- a/Src/json.c
+++ b/Src/json.c
@@ -136,8 +136,7 @@ Json_findByKey(const char* buffer, size_t buffer_size, const char* key, char* va
         size_t value_size = 0;
         ++index;
 
-        for ( ; (index < buffer_size) && (value_size < max_value_size); ++index) {
-
+        while ((index < buffer_size) && (value_size < max_value_size)) {
             value[value_size] = buffer[index];
 
             if (buffer[index] == '"') {
@@ -147,6 +146,7 @@ Json_findByKey(const char* buffer, size_t buffer_size, const char* key, char* va
             }
 
             ++value_size;
+            ++index;
         }
     }
 

--- a/Src/priority_queue.c
+++ b/Src/priority_queue.c
@@ -132,7 +132,7 @@ PriorityQueue_enqueue(PriorityQueue_t* const queue, const PriorityQueueItem_t* c
 }
 
 bool
-PriorityQueue_dequeue(PriorityQueue_t* const queue, void* const element) {
+PriorityQueue_dequeue(PriorityQueue_t* const queue, uint8_t* const element) {
     bool status = false;
     if (!PriorityQueue_isEmpty(queue)) {
         unsigned int highest_priority_index = FindHighestPriorityIndex(queue);

--- a/Src/priority_queue.c
+++ b/Src/priority_queue.c
@@ -107,9 +107,9 @@ PriorityQueue_enqueue(PriorityQueue_t* const queue, const PriorityQueueItem_t* c
         if (queue->priority_array[lowest_priority_index] < (*(item->priority))) {
             status = true;
             uint8_t* buffer = queue->buffer;
-            unsigned int i;
             queue->size = queue->size - 1U;
-            for (i = lowest_priority_index; i < queue->size; ++i) {
+            const uint32_t current_size = queue->size;
+            for (uint32_t i = lowest_priority_index; i < current_size; ++i) {
                 if (memcpy(&buffer[i * queue->element_size], &buffer[(i * queue->element_size) + queue->element_size], queue->element_size) != NULL_PTR) {
                     queue->priority_array[i] = queue->priority_array[i + 1U];
                 } else {
@@ -140,8 +140,8 @@ PriorityQueue_dequeue(PriorityQueue_t* const queue, void* const element) {
         if (memcpy(element, &buffer[highest_priority_index * queue->element_size], queue->element_size) != NULL_PTR) {
             status = true;
             queue->size = queue->size - 1U;
-            unsigned int i;
-            for (i = highest_priority_index; i < queue->size; ++i) {
+            const uint32_t current_size = queue->size;
+            for (uint32_t i = highest_priority_index; i < current_size; ++i) {
                 if (memcpy(&buffer[i * queue->element_size], &buffer[(i * queue->element_size) + queue->element_size], queue->element_size) != NULL_PTR) {
                     queue->priority_array[i] = queue->priority_array[i + 1U];
                 } else {

--- a/Src/queue.c
+++ b/Src/queue.c
@@ -62,7 +62,7 @@ Queue_isEmpty(const Queue_t* const queue) {
 }
 
 bool
-Queue_enqueue(Queue_t* const queue, const void* const element) {
+Queue_enqueue(Queue_t* const queue, const uint8_t* const element) {
     bool status = false;
     if (!Queue_isFull(queue)) {
         queue->rear = (queue->rear + 1U) % queue->capacity;
@@ -76,7 +76,7 @@ Queue_enqueue(Queue_t* const queue, const void* const element) {
 }
 
 bool
-Queue_dequeue(Queue_t* const queue, void* const element) {
+Queue_dequeue(Queue_t* const queue, uint8_t* const element) {
     bool status = false;
     if (!Queue_isEmpty(queue)) {
         const uint8_t* buffer = (const uint8_t*)queue->buffer;
@@ -90,7 +90,7 @@ Queue_dequeue(Queue_t* const queue, void* const element) {
 }
 
 bool
-Queue_front(const Queue_t* const queue, void* const element) {
+Queue_front(const Queue_t* const queue, uint8_t* const element) {
     bool status = false;
     if (!Queue_isEmpty(queue)) {
         const uint8_t* buffer = (const uint8_t*)queue->buffer;
@@ -102,7 +102,7 @@ Queue_front(const Queue_t* const queue, void* const element) {
 }
 
 bool
-Queue_rear(const Queue_t* const queue, void* const element) {
+Queue_rear(const Queue_t* const queue, uint8_t* const element) {
     bool status = false;
     if (!Queue_isEmpty(queue)) {
         const uint8_t* buffer = (const uint8_t*)queue->buffer;

--- a/Tests/test_priority_queue.c
+++ b/Tests/test_priority_queue.c
@@ -29,7 +29,7 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32) {
 
     TEST_ASSERT_TRUE(PriorityQueue_isEmpty(&queue));
     uint32_t element;
-    TEST_ASSERT_FALSE(PriorityQueue_dequeue(&queue, &element));
+    TEST_ASSERT_FALSE(PriorityQueue_dequeue(&queue, (uint8_t*)&element));
 
     // fill the queue
     PriorityQueueItem_t item;
@@ -54,9 +54,9 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32) {
     TEST_ASSERT_TRUE(PriorityQueue_enqueue(&queue, &item));
 
     // dequeue
-    TEST_ASSERT_TRUE(PriorityQueue_dequeue(&queue, &element));
+    TEST_ASSERT_TRUE(PriorityQueue_dequeue(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_UINT32(100U, element);
-    TEST_ASSERT_TRUE(PriorityQueue_dequeue(&queue, &element));
+    TEST_ASSERT_TRUE(PriorityQueue_dequeue(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_UINT32(50U, element);
 }
 
@@ -72,7 +72,7 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_float32_t) {
 
     TEST_ASSERT_TRUE(PriorityQueue_isEmpty(&queue));
     float32_t element;
-    TEST_ASSERT_FALSE(PriorityQueue_dequeue(&queue, &element));
+    TEST_ASSERT_FALSE(PriorityQueue_dequeue(&queue, (uint8_t*)&element));
 
     // fill the queue
     PriorityQueueItem_t item;
@@ -99,9 +99,9 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_float32_t) {
     TEST_ASSERT_TRUE(PriorityQueue_enqueue(&queue, &item));
 
     // dequeue
-    TEST_ASSERT_TRUE(PriorityQueue_dequeue(&queue, &element));
+    TEST_ASSERT_TRUE(PriorityQueue_dequeue(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_FLOAT(100.0F, element);
-    TEST_ASSERT_TRUE(PriorityQueue_dequeue(&queue, &element));
+    TEST_ASSERT_TRUE(PriorityQueue_dequeue(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_FLOAT(50.0F, element);
 }
 

--- a/Tests/test_queue.c
+++ b/Tests/test_queue.c
@@ -26,33 +26,33 @@ TEST(Queue, Queue_enqueue_dequeue_uint32) {
     TEST_ASSERT_FALSE(Queue_isFull(&queue));
     TEST_ASSERT_TRUE(Queue_isEmpty(&queue));
     uint32_t element;
-    TEST_ASSERT_FALSE(Queue_dequeue(&queue, &element));
+    TEST_ASSERT_FALSE(Queue_dequeue(&queue, (uint8_t*)&element));
 
     // fill the queue
     uint32_t i;
     for (i = 0U; i < capacity; ++i) {
-        TEST_ASSERT_TRUE(Queue_enqueue(&queue, &i));
+        TEST_ASSERT_TRUE(Queue_enqueue(&queue, (uint8_t*)&i));
     }
 
     // queue is full
     TEST_ASSERT_TRUE(Queue_isFull(&queue));
-    TEST_ASSERT_FALSE(Queue_enqueue(&queue, &i));
+    TEST_ASSERT_FALSE(Queue_enqueue(&queue, (uint8_t*)&i));
 
     // check front element
-    TEST_ASSERT_TRUE(Queue_front(&queue, &element));
+    TEST_ASSERT_TRUE(Queue_front(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_UINT32(0U, element);
 
     // check rear element
-    TEST_ASSERT_TRUE(Queue_rear(&queue, &element));
+    TEST_ASSERT_TRUE(Queue_rear(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_UINT32(i - 1U, element);
 
     // dequeue
-    TEST_ASSERT_TRUE(Queue_dequeue(&queue, &element));
+    TEST_ASSERT_TRUE(Queue_dequeue(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_UINT32(0U, element);
 
     // enqueue
-    TEST_ASSERT_TRUE(Queue_enqueue(&queue, &i));
-    TEST_ASSERT_TRUE(Queue_rear(&queue, &element));
+    TEST_ASSERT_TRUE(Queue_enqueue(&queue, (uint8_t*)&i));
+    TEST_ASSERT_TRUE(Queue_rear(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_UINT32(i, element);
 }
 
@@ -65,36 +65,36 @@ TEST(Queue, Queue_enqueue_dequeue_float32_t) {
     TEST_ASSERT_FALSE(Queue_isFull(&queue));
     TEST_ASSERT_TRUE(Queue_isEmpty(&queue));
     float32_t element = 1.0F;
-    TEST_ASSERT_FALSE(Queue_dequeue(&queue, &element));
+    TEST_ASSERT_FALSE(Queue_dequeue(&queue, (uint8_t*)&element));
 
     // fill the queue
     uint32_t i;
     for (i = 0U; i < capacity; ++i) {
         float32_t element_temp = (float32_t)i + 1.1F;
-        TEST_ASSERT_TRUE(Queue_enqueue(&queue, &element_temp));
+        TEST_ASSERT_TRUE(Queue_enqueue(&queue, (uint8_t*)&element_temp));
     }
 
     // queue is full
     TEST_ASSERT_TRUE(Queue_isFull(&queue));
-    TEST_ASSERT_FALSE(Queue_enqueue(&queue, &element));
+    TEST_ASSERT_FALSE(Queue_enqueue(&queue, (uint8_t*)&element));
 
     // check front element
-    TEST_ASSERT_TRUE(Queue_front(&queue, &element));
+    TEST_ASSERT_TRUE(Queue_front(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_FLOAT(1.1F, element);
 
     // check rear element
-    TEST_ASSERT_TRUE(Queue_rear(&queue, &element));
+    TEST_ASSERT_TRUE(Queue_rear(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_FLOAT((float32_t)capacity - 1.0F + 1.1F, element);
 
     // dequeue
-    TEST_ASSERT_TRUE(Queue_dequeue(&queue, &element));
+    TEST_ASSERT_TRUE(Queue_dequeue(&queue, (uint8_t*)&element));
     TEST_ASSERT_EQUAL_FLOAT(1.1F, element);
 
     // enqueue
     element = 5.1F;
-    TEST_ASSERT_TRUE(Queue_enqueue(&queue, &element));
+    TEST_ASSERT_TRUE(Queue_enqueue(&queue, (uint8_t*)&element));
     float32_t test_element;
-    TEST_ASSERT_TRUE(Queue_rear(&queue, &test_element));
+    TEST_ASSERT_TRUE(Queue_rear(&queue, (uint8_t*)&test_element));
     TEST_ASSERT_EQUAL_FLOAT(test_element, element);
 }
 


### PR DESCRIPTION
14.2 - A 'for' loop shall be well-formed.
21.15 - The pointer arguments to the Standard Library functions 'memcpy', 'memmove' and 'memcmp' shall be pointers to qualified or unqualified versions of compatible types.