### PR TITLE
Fix violation of MISRA rule 4.6

### DIFF
--- a/Inc/base64.h
+++ b/Inc/base64.h
@@ -5,7 +5,7 @@
 
 #include <string.h>
 
-int Base64_encode(const char* data, size_t data_length, char* result, size_t max_result_length);
-int Base64_decode(const char* in, size_t in_len, uint8_t* out, size_t max_out_len);
+int32_t Base64_encode(const char* data, size_t data_length, char* result, size_t max_result_length);
+int32_t Base64_decode(const char* in, size_t in_len, uint8_t* out, size_t max_out_len);
 
 #endif /* UTILITY_BASE64_H_ */

--- a/Inc/bubble_sort.h
+++ b/Inc/bubble_sort.h
@@ -37,6 +37,6 @@
 
 #include "typedefs.h"
 
-void BubbleSort_sort(uint8_t* buffer, const int number_of_elements, const unsigned int element_size, bool (*compareFun)(void* first, void* second));
+void BubbleSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size, bool (*compareFun)(void* first, void* second));
 
 #endif /* UTILITY_BUBBLE_SORT_H_ */

--- a/Inc/heap_sort.h
+++ b/Inc/heap_sort.h
@@ -37,6 +37,6 @@
 
 #include "typedefs.h"
 
-void HeapSort_sort(uint8_t* buffer, const int number_of_elements, const unsigned int element_size, bool (*compareFun)(void* first, void* second));
+void HeapSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size, bool (*compareFun)(void* first, void* second));
 
 #endif /* UTILITY_HEAP_SORT_H_ */

--- a/Inc/priority_queue.h
+++ b/Inc/priority_queue.h
@@ -38,19 +38,19 @@
 #include "typedefs.h"
 
 typedef struct {
-    unsigned int* priority;
+    uint32_t* priority;
     uint8_t* element;
 } PriorityQueueItem_t;
 
 typedef struct {
     uint32_t size;
     uint32_t capacity;
-    unsigned int element_size;
-    unsigned int* priority_array;
+    uint32_t element_size;
+    uint32_t* priority_array;
     uint8_t* buffer;
 } PriorityQueue_t;
 
-bool PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const unsigned int element_size, const PriorityQueueItem_t* items);
+bool PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const uint32_t element_size, const PriorityQueueItem_t* items);
 bool PriorityQueue_isEmpty(const PriorityQueue_t* const queue);
 bool PriorityQueue_enqueue(PriorityQueue_t* const queue, const PriorityQueueItem_t* const item);
 bool PriorityQueue_dequeue(PriorityQueue_t* const queue, uint8_t* const element);

--- a/Inc/queue.h
+++ b/Inc/queue.h
@@ -38,15 +38,15 @@
 #include "typedefs.h"
 
 typedef struct {
-    unsigned int front;
+    uint32_t front;
     uint32_t rear;
-    unsigned int size;
+    uint32_t size;
     uint32_t capacity;
-    unsigned int element_size;
+    uint32_t element_size;
     uint8_t* buffer;
 } Queue_t;
 
-bool Queue_initQueue(Queue_t* const queue, const uint32_t capacity, const unsigned int element_size, uint8_t* buffer);
+bool Queue_initQueue(Queue_t* const queue, const uint32_t capacity, const uint32_t element_size, uint8_t* buffer);
 bool Queue_isFull(const Queue_t* const queue);
 bool Queue_isEmpty(const Queue_t* const queue);
 bool Queue_enqueue(Queue_t* const queue, const uint8_t* const element);

--- a/Inc/scheduler.h
+++ b/Inc/scheduler.h
@@ -42,8 +42,8 @@ typedef struct {
     bool active;
 } SchedulerTask_t;
 
-void Scheduler_init(SchedulerTask_t* tasks, const unsigned int num_of_tasks);
-bool Scheduler_addTask(SchedulerTask_t* tasks, const unsigned int max_num_tasks, const SchedulerTask_t* const new_task);
-void Scheduler_run(const SchedulerTask_t* task, const unsigned int num_of_tasks);
+void Scheduler_init(SchedulerTask_t* tasks, const uint32_t num_of_tasks);
+bool Scheduler_addTask(SchedulerTask_t* tasks, const uint32_t max_num_tasks, const SchedulerTask_t* const new_task);
+void Scheduler_run(const SchedulerTask_t* task, const uint32_t num_of_tasks);
 
 #endif /* UTILITY_SCHEDULER_H_ */

--- a/Src/base64.c
+++ b/Src/base64.c
@@ -18,29 +18,29 @@
 
 #include "base64.h"
 
-int
+int32_t
 Base64_encode(const char* data, size_t data_length, char* result, size_t max_result_length) {
-    int success = 0;
-    const unsigned char base64_table[65] = {
-        (unsigned char)'A', (unsigned char)'B', (unsigned char)'C', (unsigned char)'D',
-        (unsigned char)'E', (unsigned char)'F', (unsigned char)'G', (unsigned char)'H',
-        (unsigned char)'I', (unsigned char)'J', (unsigned char)'K', (unsigned char)'L',
-        (unsigned char)'M', (unsigned char)'N', (unsigned char)'O', (unsigned char)'P',
-        (unsigned char)'Q', (unsigned char)'R', (unsigned char)'S', (unsigned char)'T',
-        (unsigned char)'U', (unsigned char)'V', (unsigned char)'W', (unsigned char)'X',
-        (unsigned char)'Y', (unsigned char)'Z', (unsigned char)'a', (unsigned char)'b',
-        (unsigned char)'c', (unsigned char)'d', (unsigned char)'e', (unsigned char)'f',
-        (unsigned char)'g', (unsigned char)'h', (unsigned char)'i', (unsigned char)'j',
-        (unsigned char)'k', (unsigned char)'l', (unsigned char)'m', (unsigned char)'n',
-        (unsigned char)'o', (unsigned char)'p', (unsigned char)'q', (unsigned char)'r',
-        (unsigned char)'s', (unsigned char)'t', (unsigned char)'u', (unsigned char)'v',
-        (unsigned char)'w', (unsigned char)'x', (unsigned char)'y', (unsigned char)'z',
-        (unsigned char)'0', (unsigned char)'1', (unsigned char)'2', (unsigned char)'3',
-        (unsigned char)'4', (unsigned char)'5', (unsigned char)'6', (unsigned char)'7',
-        (unsigned char)'8', (unsigned char)'9', (unsigned char)'+', (unsigned char)'/',
-        (unsigned char)'\0'
+    int32_t success = 0;
+    const uint8_t base64_table[65] = {
+        (uint8_t)'A', (uint8_t)'B', (uint8_t)'C', (uint8_t)'D',
+        (uint8_t)'E', (uint8_t)'F', (uint8_t)'G', (uint8_t)'H',
+        (uint8_t)'I', (uint8_t)'J', (uint8_t)'K', (uint8_t)'L',
+        (uint8_t)'M', (uint8_t)'N', (uint8_t)'O', (uint8_t)'P',
+        (uint8_t)'Q', (uint8_t)'R', (uint8_t)'S', (uint8_t)'T',
+        (uint8_t)'U', (uint8_t)'V', (uint8_t)'W', (uint8_t)'X',
+        (uint8_t)'Y', (uint8_t)'Z', (uint8_t)'a', (uint8_t)'b',
+        (uint8_t)'c', (uint8_t)'d', (uint8_t)'e', (uint8_t)'f',
+        (uint8_t)'g', (uint8_t)'h', (uint8_t)'i', (uint8_t)'j',
+        (uint8_t)'k', (uint8_t)'l', (uint8_t)'m', (uint8_t)'n',
+        (uint8_t)'o', (uint8_t)'p', (uint8_t)'q', (uint8_t)'r',
+        (uint8_t)'s', (uint8_t)'t', (uint8_t)'u', (uint8_t)'v',
+        (uint8_t)'w', (uint8_t)'x', (uint8_t)'y', (uint8_t)'z',
+        (uint8_t)'0', (uint8_t)'1', (uint8_t)'2', (uint8_t)'3',
+        (uint8_t)'4', (uint8_t)'5', (uint8_t)'6', (uint8_t)'7',
+        (uint8_t)'8', (uint8_t)'9', (uint8_t)'+', (uint8_t)'/',
+        (uint8_t)'\0'
     };
-    unsigned char* out;
+    uint8_t* out;
     uint8_t* pos;
     const uint8_t* in = (const uint8_t*) data;
 
@@ -53,7 +53,7 @@ Base64_encode(const char* data, size_t data_length, char* result, size_t max_res
     }
 
     if (success == 0) {
-        out = (unsigned char*)&result[0];
+        out = (uint8_t*)&result[0];
         pos = out;
         while ((data_length - in_position) >= 3U) {
             current_length += 4U;
@@ -106,9 +106,9 @@ Base64_encode(const char* data, size_t data_length, char* result, size_t max_res
     return success;
 }
 
-int
+int32_t
 Base64_decode(const char* in, size_t in_len, uint8_t* out, size_t max_out_len) {
-    int success = 0;
+    int32_t success = 0;
     const uint32_t base64_index[256] = {
         0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
         0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
@@ -125,9 +125,9 @@ Base64_decode(const char* in, size_t in_len, uint8_t* out, size_t max_out_len) {
         0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
         0U
     };
-    const unsigned char* in_data_uchar = (const unsigned char*)in;
-    bool pad_bool = (in_len > 0U) && (((in_len % 4U) != 0U) || (in_data_uchar[in_len - 1U] == (unsigned char)'='));
-    unsigned int pad_uint = 0U;
+    const uint8_t* in_data_uchar = (const uint8_t*)in;
+    bool pad_bool = (in_len > 0U) && (((in_len % 4U) != 0U) || (in_data_uchar[in_len - 1U] == (uint8_t)'='));
+    uint32_t pad_uint = 0U;
     if (pad_bool) {
         pad_uint = 1U;
     }
@@ -154,7 +154,7 @@ Base64_decode(const char* in, size_t in_len, uint8_t* out, size_t max_out_len) {
             uint32_t n = (base64_index[in_data_uchar[len]] << 18U) | (base64_index[in_data_uchar[len + 1U]] << 12U);
             out[out_len - 1U] = (uint8_t)(n >> 16U);
 
-            if ((in_len > (len + 2U)) && (in_data_uchar[len + 2U] != (unsigned char)'=')) {
+            if ((in_len > (len + 2U)) && (in_data_uchar[len + 2U] != (uint8_t)'=')) {
                 if ((out_len + 1U) > max_out_len) {
                     success = 1;
                 } else {

--- a/Src/bubble_sort.c
+++ b/Src/bubble_sort.c
@@ -37,15 +37,13 @@
 #include "utils.h"
 
 void
-BubbleSort_sort(uint8_t* buffer, const int number_of_elements, const unsigned int element_size, bool (*compareFun)(void* first, void* second)) {
-    int i;
-    int j;
+BubbleSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size, bool (*compareFun)(void* first, void* second)) {
     uint8_t* elements = buffer;
-    for (i = 0; i < (number_of_elements - 1); ++i) {
+    for (int32_t i = 0; i < (number_of_elements - 1); ++i) {
         bool swapped = false;
-        for (j = 0; j < (number_of_elements - i - 1); ++j) {
-            if (compareFun(&elements[j * (int)element_size], &elements[(j + 1) * (int)element_size])) {
-                Utils_SwapElements(&elements[j * (int)element_size], &elements[(j + 1) * (int)element_size], element_size);
+        for (int32_t j = 0; j < (number_of_elements - i - 1); ++j) {
+            if (compareFun(&elements[j * (int32_t)element_size], &elements[(j + 1) * (int32_t)element_size])) {
+                Utils_SwapElements(&elements[j * (int32_t)element_size], &elements[(j + 1) * (int32_t)element_size], element_size);
                 swapped = true;
             }
         }

--- a/Src/heap_sort.c
+++ b/Src/heap_sort.c
@@ -37,30 +37,30 @@
 #include "utils.h"
 
 static void
-Heapify(uint8_t* buffer, const int n, const int i, const unsigned int element_size, bool (*compareFun)(void* first, void* second)) {
+Heapify(uint8_t* buffer, const int32_t n, const int32_t i, const uint32_t element_size, bool (*compareFun)(void* first, void* second)) {
     bool continue_iterating = true;
-    int index = i;
+    int32_t index = i;
     uint8_t* elements = buffer;
 
     while (continue_iterating) {
-        int largest = index;
-        int left = (2 * index) + 1;
-        int right = (2 * index) + 2;
+        int32_t largest = index;
+        int32_t left = (2 * index) + 1;
+        int32_t right = (2 * index) + 2;
 
-        bool compare_ret_value = compareFun(&elements[left * (int)element_size], &elements[largest * (int)element_size]);
+        bool compare_ret_value = compareFun(&elements[left * (int32_t)element_size], &elements[largest * (int32_t)element_size]);
 
         if ((left < n) && (compare_ret_value)) {
             largest = left;
         }
 
-        compare_ret_value = compareFun(&elements[right * (int)element_size], &elements[largest * (int)element_size]);
+        compare_ret_value = compareFun(&elements[right * (int32_t)element_size], &elements[largest * (int32_t)element_size]);
 
         if ((right < n) && (compare_ret_value)) {
             largest = right;
         }
 
         if (largest != index) {
-            Utils_SwapElements(&elements[index * (int)element_size], &elements[largest * (int)element_size], element_size);
+            Utils_SwapElements(&elements[index * (int32_t)element_size], &elements[largest * (int32_t)element_size], element_size);
             index = largest;
         } else {
             continue_iterating = false;
@@ -69,15 +69,15 @@ Heapify(uint8_t* buffer, const int n, const int i, const unsigned int element_si
 }
 
 void
-HeapSort_sort(uint8_t* buffer, const int number_of_elements, const unsigned int element_size, bool (*compareFun)(void* first, void* second)) {
-    int i;
+HeapSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size, bool (*compareFun)(void* first, void* second)) {
+    int32_t i;
     uint8_t* elements = buffer;
     for (i = (number_of_elements / 2) - 1; i >= 0; --i) {
         Heapify(elements, number_of_elements, i, element_size, compareFun);
     }
 
     for (i = number_of_elements - 1; i >= 0; --i) {
-        Utils_SwapElements(&elements[0], &elements[i * (int)element_size], element_size);
+        Utils_SwapElements(&elements[0], &elements[i * (int32_t)element_size], element_size);
         Heapify(elements, i, 0, element_size, compareFun);
     }
 }

--- a/Src/priority_queue.c
+++ b/Src/priority_queue.c
@@ -41,13 +41,12 @@ IsPriorityQueueFull(const PriorityQueue_t* const queue) {
     return (queue->size == queue->capacity);
 }
 
-static unsigned int
+static uint32_t
 FindHighestPriorityIndex(const PriorityQueue_t* const queue) {
-    unsigned int highest_priority = queue->priority_array[0];
-    unsigned int index = 0U;
-    unsigned int i;
+    uint32_t highest_priority = queue->priority_array[0];
+    uint32_t index = 0U;
 
-    for (i = 0U; i < queue->size; ++i) {
+    for (uint32_t i = 0U; i < queue->size; ++i) {
         if (highest_priority < queue->priority_array[i]) {
             highest_priority = queue->priority_array[i];
             index = i;
@@ -57,13 +56,12 @@ FindHighestPriorityIndex(const PriorityQueue_t* const queue) {
     return index;
 }
 
-static unsigned int
+static uint32_t
 FindLowestPriorityIndex(const PriorityQueue_t* const queue) {
-    unsigned int lowest_priority = queue->priority_array[0];
-    unsigned int index = 0U;
-    unsigned int i;
+    uint32_t lowest_priority = queue->priority_array[0];
+    uint32_t index = 0U;
 
-    for (i = 0U; i < queue->size; ++i) {
+    for (uint32_t i = 0U; i < queue->size; ++i) {
         if (lowest_priority > queue->priority_array[i]) {
             lowest_priority = queue->priority_array[i];
             index = i;
@@ -74,7 +72,7 @@ FindLowestPriorityIndex(const PriorityQueue_t* const queue) {
 }
 
 bool
-PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const unsigned int element_size, const PriorityQueueItem_t* items) {
+PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const uint32_t element_size, const PriorityQueueItem_t* items) {
     bool status = false;
     if (capacity != 0U) {
         queue->capacity = capacity;
@@ -103,7 +101,7 @@ PriorityQueue_enqueue(PriorityQueue_t* const queue, const PriorityQueueItem_t* c
             status = true;
         }
     } else {
-        unsigned int lowest_priority_index = FindLowestPriorityIndex(queue);
+        uint32_t lowest_priority_index = FindLowestPriorityIndex(queue);
         if (queue->priority_array[lowest_priority_index] < (*(item->priority))) {
             status = true;
             uint8_t* buffer = queue->buffer;
@@ -135,7 +133,7 @@ bool
 PriorityQueue_dequeue(PriorityQueue_t* const queue, uint8_t* const element) {
     bool status = false;
     if (!PriorityQueue_isEmpty(queue)) {
-        unsigned int highest_priority_index = FindHighestPriorityIndex(queue);
+        uint32_t highest_priority_index = FindHighestPriorityIndex(queue);
         uint8_t* buffer = queue->buffer;
         if (memcpy(element, &buffer[highest_priority_index * queue->element_size], queue->element_size) != NULL_PTR) {
             status = true;

--- a/Src/queue.c
+++ b/Src/queue.c
@@ -37,7 +37,7 @@
 #include <string.h>
 
 bool
-Queue_initQueue(Queue_t* const queue, const uint32_t capacity, const unsigned int element_size, uint8_t* buffer) {
+Queue_initQueue(Queue_t* const queue, const uint32_t capacity, const uint32_t element_size, uint8_t* buffer) {
     bool status = false;
     if (capacity != 0U) {
         queue->capacity = capacity;

--- a/Src/scheduler.c
+++ b/Src/scheduler.c
@@ -35,19 +35,17 @@
 #include "scheduler.h"
 
 void
-Scheduler_init(SchedulerTask_t* tasks, const unsigned int num_of_tasks) {
-    unsigned int i;
-    for (i = 0U; i < num_of_tasks; ++i) {
+Scheduler_init(SchedulerTask_t* tasks, const uint32_t num_of_tasks) {
+    for (uint32_t i = 0U; i < num_of_tasks; ++i) {
         tasks[i].function = NULL_PTR;
         tasks[i].active = false;
     }
 }
 
 bool
-Scheduler_addTask(SchedulerTask_t* tasks, const unsigned int max_num_tasks, const SchedulerTask_t* const new_task) {
+Scheduler_addTask(SchedulerTask_t* tasks, const uint32_t max_num_tasks, const SchedulerTask_t* const new_task) {
     bool status = false;
-    unsigned int i;
-    for (i = 0U; i < max_num_tasks; ++i) {
+    for (uint32_t i = 0U; i < max_num_tasks; ++i) {
         if (tasks[i].function == NULL_PTR) {
             tasks[i].function = new_task->function;
             tasks[i].active = new_task->active;
@@ -59,9 +57,8 @@ Scheduler_addTask(SchedulerTask_t* tasks, const unsigned int max_num_tasks, cons
 }
 
 void
-Scheduler_run(const SchedulerTask_t* task, const unsigned int num_of_tasks) {
-    unsigned int i;
-    for (i = 0U; i < num_of_tasks; ++i) {
+Scheduler_run(const SchedulerTask_t* task, const uint32_t num_of_tasks) {
+    for (uint32_t i = 0U; i < num_of_tasks; ++i) {
         if ((task[i].function != NULL_PTR) && (task[i].active)) {
             task[i].function();
         }

--- a/Tests/Helper/sort_functions.c
+++ b/Tests/Helper/sort_functions.c
@@ -1,12 +1,10 @@
 #include "sort_functions.h"
 
-#include <stdint.h>
-
 bool
-CompareInt(void* first, void* second) {
+CompareInt32(void* first, void* second) {
     bool ret_val = false;
-    int* first_element = first;
-    int* second_element = second;
+    int32_t* first_element = first;
+    int32_t* second_element = second;
     if (*first_element > *second_element) {
         ret_val = true;
     }
@@ -14,10 +12,10 @@ CompareInt(void* first, void* second) {
 }
 
 bool
-CompareDouble(void* first, void* second) {
+CompareFloat64(void* first, void* second) {
     bool ret_val = false;
-    double* first_element = first;
-    double* second_element = second;
+    float64_t* first_element = first;
+    float64_t* second_element = second;
     if (*first_element > *second_element) {
         ret_val = true;
     }

--- a/Tests/Helper/sort_functions.h
+++ b/Tests/Helper/sort_functions.h
@@ -1,5 +1,5 @@
-#include <stdbool.h>
+#include "typedefs.h"
 
-bool CompareInt(void* first, void* second);
-bool CompareDouble(void* first, void* second);
+bool CompareInt32(void* first, void* second);
+bool CompareFloat64(void* first, void* second);
 bool CompareUint64(void* first, void* second);

--- a/Tests/test_base64.c
+++ b/Tests/test_base64.c
@@ -20,30 +20,30 @@ TEST(Base64, Base64_encode) {
     {
         const char string[] = "IMProject is a very cool project!";
         char base64[200];
-        int success = Base64_encode(string, strlen(string), base64, sizeof(base64));
+        int32_t success = Base64_encode(string, strlen(string), base64, sizeof(base64));
         TEST_ASSERT_EQUAL_STRING("SU1Qcm9qZWN0IGlzIGEgdmVyeSBjb29sIHByb2plY3Qh", base64);
-        TEST_ASSERT_EQUAL_INT(0, success);
+        TEST_ASSERT_EQUAL_INT32(0, success);
     }
     {
         // Result length is too small
         const char string[] = "IMProject is a very cool project!";
         char base64[10];
-        int success = Base64_encode(string, strlen(string), base64, sizeof(base64));
-        TEST_ASSERT_EQUAL_INT(1, success);
+        int32_t success = Base64_encode(string, strlen(string), base64, sizeof(base64));
+        TEST_ASSERT_EQUAL_INT32(1, success);
     }
     {
         const char string[] = "Hehe";
         char base64[200];
-        int success = Base64_encode(string, strlen(string), base64, sizeof(base64));
+        int32_t success = Base64_encode(string, strlen(string), base64, sizeof(base64));
         TEST_ASSERT_EQUAL_STRING("SGVoZQ==", base64);
-        TEST_ASSERT_EQUAL_INT(0, success);
+        TEST_ASSERT_EQUAL_INT32(0, success);
     }
     {
         // Result length is too small
         const char string[] = "Hehe";
         char base64[4];
-        int success = Base64_encode(string, strlen(string), base64, sizeof(base64));
-        TEST_ASSERT_EQUAL_INT(1, success);
+        int32_t success = Base64_encode(string, strlen(string), base64, sizeof(base64));
+        TEST_ASSERT_EQUAL_INT32(1, success);
     }
 }
 
@@ -52,30 +52,30 @@ TEST(Base64, Base64_decode) {
         char text[] = "IMProject is a very cool project!";
         char base64[] = "SU1Qcm9qZWN0IGlzIGEgdmVyeSBjb29sIHByb2plY3Qh";
         uint8_t string[200];
-        int success = Base64_decode(base64, strlen(base64), string, sizeof(string));
+        int32_t success = Base64_decode(base64, strlen(base64), string, sizeof(string));
         TEST_ASSERT_EQUAL_MEMORY(text, string, strlen(text));
-        TEST_ASSERT_EQUAL_INT(0, success);
+        TEST_ASSERT_EQUAL_INT32(0, success);
     }
     {
         // Output size is too big
         char base64[] = "SU1Qcm9qZWN0IGlzIGEgdmVyeSBjb29sIHByb2plY3Qh";
         uint8_t string[10];
-        int success = Base64_decode(base64, strlen(base64), string, sizeof(string));
-        TEST_ASSERT_EQUAL_INT(1, success);
+        int32_t success = Base64_decode(base64, strlen(base64), string, sizeof(string));
+        TEST_ASSERT_EQUAL_INT32(1, success);
     }
     {
         char text[] = "B?E(H+MbQeThWmZq4t7w!z%C*F)J@NcR";
         char base64[] = "Qj9FKEgrTWJRZVRoV21acTR0N3cheiVDKkYpSkBOY1I=";
         uint8_t string[200];
-        int success = Base64_decode(base64, strlen(base64), string, sizeof(string));
+        int32_t success = Base64_decode(base64, strlen(base64), string, sizeof(string));
         TEST_ASSERT_EQUAL_MEMORY(text, string, strlen(text));
-        TEST_ASSERT_EQUAL_INT(0, success);
+        TEST_ASSERT_EQUAL_INT32(0, success);
     }
     {
         // Output size is too big
         char base64[] = "Qj9FKEgrTWJRZVRoV21acTR0N3cheiVDKkYpSkBOY1I=";
         uint8_t string[31];
-        int success = Base64_decode(base64, strlen(base64), string, sizeof(string));
-        TEST_ASSERT_EQUAL_INT(1, success);
+        int32_t success = Base64_decode(base64, strlen(base64), string, sizeof(string));
+        TEST_ASSERT_EQUAL_INT32(1, success);
     }
 }

--- a/Tests/test_bubble_sort.c
+++ b/Tests/test_bubble_sort.c
@@ -14,29 +14,27 @@ TEST_TEAR_DOWN(BubbleSort) {
 }
 
 TEST_GROUP_RUNNER(BubbleSort) {
-    RUN_TEST_CASE(BubbleSort, BubbleSort_int);
-    RUN_TEST_CASE(BubbleSort, BubbleSort_double);
+    RUN_TEST_CASE(BubbleSort, BubbleSort_int32);
+    RUN_TEST_CASE(BubbleSort, BubbleSort_float64);
     RUN_TEST_CASE(BubbleSort, BubbleSort_uint64);
 }
 
-TEST(BubbleSort, BubbleSort_int) {
-    int unsorted_array[] = {5, 2, 3, 1000000, 9, 10, 11, 8, 9, 100};
-    const int sorted_array[] = {2, 3, 5, 8, 9, 9, 10, 11, 100, 1000000};
-    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareInt);
+TEST(BubbleSort, BubbleSort_int32) {
+    int32_t unsorted_array[] = {5, 2, 3, 1000000, 9, 10, 11, 8, 9, 100};
+    const int32_t sorted_array[] = {2, 3, 5, 8, 9, 9, 10, 11, 100, 1000000};
+    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareInt32);
 
-    unsigned int i;
-    for (i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
-        TEST_ASSERT_EQUAL_INT(unsorted_array[i], sorted_array[i]);
+    for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
+        TEST_ASSERT_EQUAL_INT32(unsorted_array[i], sorted_array[i]);
     }
 }
 
-TEST(BubbleSort, BubbleSort_double) {
-    double unsorted_array[] = {5.8, 2.2, 3.1, 1.1, 9.1, 10.3, 11.2, 8.4, 9.2, 100.9};
-    const double sorted_array[] = {1.1, 2.2, 3.1, 5.8, 8.4, 9.1, 9.2, 10.3, 11.2, 100.9};
-    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareDouble);
+TEST(BubbleSort, BubbleSort_float64) {
+    float64_t unsorted_array[] = {5.8, 2.2, 3.1, 1.1, 9.1, 10.3, 11.2, 8.4, 9.2, 100.9};
+    const float64_t sorted_array[] = {1.1, 2.2, 3.1, 5.8, 8.4, 9.1, 9.2, 10.3, 11.2, 100.9};
+    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareFloat64);
 
-    unsigned int i;
-    for (i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
+    for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
         TEST_ASSERT_EQUAL_DOUBLE(unsorted_array[i], sorted_array[i]);
     }
 }
@@ -46,8 +44,7 @@ TEST(BubbleSort, BubbleSort_uint64) {
     const uint64_t sorted_array[] = {1U, 2U, 3U, 5U, 1111U, 44444U, 212121U, 1111111U, 55555555U, 10000000000000U};
     BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareUint64);
 
-    unsigned int i;
-    for (i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
+    for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
         TEST_ASSERT_EQUAL_UINT64(unsorted_array[i], sorted_array[i]);
     }
 }

--- a/Tests/test_heap_sort.c
+++ b/Tests/test_heap_sort.c
@@ -14,29 +14,27 @@ TEST_TEAR_DOWN(HeapSort) {
 }
 
 TEST_GROUP_RUNNER(HeapSort) {
-    RUN_TEST_CASE(HeapSort, HeapSort_int);
-    RUN_TEST_CASE(HeapSort, HeapSort_double);
+    RUN_TEST_CASE(HeapSort, HeapSort_int32);
+    RUN_TEST_CASE(HeapSort, HeapSort_float64);
     RUN_TEST_CASE(HeapSort, HeapSort_uint64);
 }
 
-TEST(HeapSort, HeapSort_int) {
-    int unsorted_array[] = {5, 2, 3, 1000000, 9, 10, 11, 8, 9, 100};
-    const int sorted_array[] = {2, 3, 5, 8, 9, 9, 10, 11, 100, 1000000};
-    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareInt);
+TEST(HeapSort, HeapSort_int32) {
+    int32_t unsorted_array[] = {5, 2, 3, 1000000, 9, 10, 11, 8, 9, 100};
+    const int32_t sorted_array[] = {2, 3, 5, 8, 9, 9, 10, 11, 100, 1000000};
+    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareInt32);
 
-    unsigned int i;
-    for (i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
-        TEST_ASSERT_EQUAL_INT(unsorted_array[i], sorted_array[i]);
+    for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
+        TEST_ASSERT_EQUAL_INT32(unsorted_array[i], sorted_array[i]);
     }
 }
 
-TEST(HeapSort, HeapSort_double) {
-    double unsorted_array[] = {5.8, 2.2, 3.1, 1.1, 9.1, 10.3, 11.2, 8.4, 9.2, 100.9};
-    const double sorted_array[] = {1.1, 2.2, 3.1, 5.8, 8.4, 9.1, 9.2, 10.3, 11.2, 100.9};
-    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareDouble);
+TEST(HeapSort, HeapSort_float64) {
+    float64_t unsorted_array[] = {5.8, 2.2, 3.1, 1.1, 9.1, 10.3, 11.2, 8.4, 9.2, 100.9};
+    const float64_t sorted_array[] = {1.1, 2.2, 3.1, 5.8, 8.4, 9.1, 9.2, 10.3, 11.2, 100.9};
+    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareFloat64);
 
-    unsigned int i;
-    for (i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
+    for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
         TEST_ASSERT_EQUAL_DOUBLE(unsorted_array[i], sorted_array[i]);
     }
 }
@@ -46,8 +44,7 @@ TEST(HeapSort, HeapSort_uint64) {
     const uint64_t sorted_array[] = {1U, 2U, 3U, 5U, 1111U, 44444U, 212121U, 1111111U, 55555555U, 10000000000000U};
     HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareUint64);
 
-    unsigned int i;
-    for (i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
+    for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
         TEST_ASSERT_EQUAL_UINT64(unsorted_array[i], sorted_array[i]);
     }
 }

--- a/Tests/test_priority_queue.c
+++ b/Tests/test_priority_queue.c
@@ -19,7 +19,7 @@ TEST_GROUP_RUNNER(PriorityQueue) {
 
 TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32) {
     uint32_t buffer[100];
-    unsigned int priority_array[100];
+    uint32_t priority_array[100];
     PriorityQueueItem_t items;
     items.element = (uint8_t*)buffer;
     items.priority = priority_array;
@@ -34,7 +34,7 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32) {
     // fill the queue
     PriorityQueueItem_t item;
     uint32_t i;
-    unsigned int priority;
+    uint32_t priority;
     item.priority = &priority;
     for (i = 0U; i < capacity; ++i) {
         priority = 1U;
@@ -62,7 +62,7 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32) {
 
 TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_float32_t) {
     float32_t buffer[100];
-    unsigned int priority_array[100];
+    uint32_t priority_array[100];
     PriorityQueueItem_t items;
     items.element = (uint8_t*)buffer;
     items.priority = priority_array;
@@ -77,7 +77,7 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_float32_t) {
     // fill the queue
     PriorityQueueItem_t item;
     uint32_t i;
-    unsigned int priority;
+    uint32_t priority;
     item.priority = &priority;
     item.element = (uint8_t*)&element;
     element = 0.0F;


### PR DESCRIPTION
typedefs that indicate size and signedness should be used in place of the basic numerical types.