### PR TITLE
Add Utils_Strncmp function

### DIFF
--- a/Inc/utils.h
+++ b/Inc/utils.h
@@ -39,6 +39,7 @@
 
 bool Utils_QuickUint32Pow10(const uint8_t exponent, uint32_t* result);
 bool Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* integer);
+int32_t Utils_Strncmp(const char* str1, const char* str2, const uint32_t num);
 void Utils_SwapElements(uint8_t* first, uint8_t* second, const uint32_t size);
 
 // Big-endian

--- a/Src/json.c
+++ b/Src/json.c
@@ -34,6 +34,8 @@
 
 #include "json.h"
 
+#include "utils.h"
+
 #define MINIMAL_SIZE 2U // size of '{' or '}' + '\0'
 
 bool
@@ -109,11 +111,11 @@ Json_findByKey(const char* buffer, size_t buffer_size, const char* key, char* va
     uint32_t max_search_size = (uint32_t)(buffer_size - strlen(key));
 
     uint32_t index;
-    size_t key_size = strlen(key);
+    uint32_t key_size = (uint32_t)strlen(key);
 
     for (index = 0; index < max_search_size; ++index) {
 
-        if (0 == strncmp(&buffer[index], key, key_size)) {
+        if (0 == Utils_Strncmp(&buffer[index], key, key_size)) {
 
             if (buffer[index + key_size] == '"') {
                 success = true;

--- a/Src/utils.c
+++ b/Src/utils.c
@@ -105,6 +105,22 @@ Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* intege
     return success;
 }
 
+int32_t
+Utils_Strncmp(const char* str1, const char* str2, const uint32_t num) {
+
+    int32_t ret_val = 0;
+
+    for (uint32_t i = 0U; (i < num) && (str1[i] != '\0') && (str2[i] != '\0'); ++i) {
+
+        if (str1[i] != str2[i]) {
+            ret_val = str1[i] - str2[i];
+            break;
+        }
+    }
+
+    return ret_val;
+}
+
 void
 Utils_SwapElements(uint8_t* first, uint8_t* second, const uint32_t size) {
     uint8_t temp;

--- a/Tests/test_utils.c
+++ b/Tests/test_utils.c
@@ -24,6 +24,7 @@ TEST_TEAR_DOWN(Utils) {
 TEST_GROUP_RUNNER(Utils) {
     RUN_TEST_CASE(Utils, Utils_QuickUint32Pow10);
     RUN_TEST_CASE(Utils, Utils_StringToUint32);
+    RUN_TEST_CASE(Utils, Utils_Strncmp);
     RUN_TEST_CASE(Utils, Utils_SwapElements);
     RUN_TEST_CASE(Utils, Utils_SerializeBlobBE);
     RUN_TEST_CASE(Utils, Utils_DeserializeBlobBE);
@@ -83,6 +84,25 @@ TEST(Utils, Utils_StringToUint32) {
 
     char not_a_number_4_string[] = "429496729A";
     TEST_ASSERT_FALSE(Utils_StringToUint32(not_a_number_4_string, strlen(not_a_number_4_string), &ui32_number));
+}
+
+TEST(Utils, Utils_Strncmp) {
+
+    char str_base[] = "BSdasdasd!eienfef";
+    char str_equal[] = "BSdasdasd!eienfef";
+    TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_equal, strlen(str_base)), 0);
+
+    char str_first_char_diff1[] = "ASdasdasd!eienfef";
+    TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_first_char_diff1, strlen(str_base)), 1);
+
+    char str_first_char_diff2[] = "CSdasdasd!eienfef";
+    TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_first_char_diff2, strlen(str_base)), -1);
+
+    char str_shorter_than_base[] = "BSda";
+    TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_shorter_than_base, strlen(str_base)), 0);
+
+    char str_longer_than_base[] = "BSdasdasd!eienfefAA";
+    TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_longer_than_base, strlen(str_base)), 0);
 }
 
 TEST(Utils, Utils_SwapElements) {


### PR DESCRIPTION
Added our own strncmp function modeled on one from string.h

This is done to solve MISRA C:2012 Amendment 1 Rule 21.18 that says: "The size_t argument passed to any function in <string.h> shall have an appropriate value".

Since we would like to have variable sizes of both strings and keys inside the `Json_findByKey` function this imposed itself as a logical solution.

Edit:
There was no need for this, see: https://github.com/IMProject/IMUtility/pull/40
Don't replace library strncmp (faster, optimized) with a handwritten version in your code

 