### PR TITLE
Add Utils_Memcpy function

### DIFF
--- a/Inc/utils.h
+++ b/Inc/utils.h
@@ -37,6 +37,7 @@
 
 #include "typedefs.h"
 
+void Utils_Memcpy(uint8_t* to, const uint8_t* from, const uint32_t size);
 bool Utils_QuickUint32Pow10(const uint8_t exponent, uint32_t* result);
 bool Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* integer);
 int32_t Utils_Strncmp(const char* str1, const char* str2, const uint32_t num);
@@ -56,6 +57,5 @@ void Utils_Deserialize8BE(const uint8_t* buf, uint8_t* value);
 // Little-endian
 void Utils_SerializeBlobLE(uint8_t* buf, const uint8_t* src, uint32_t size);
 void Utils_DeserializeBlobLE(const uint8_t* buf, uint8_t* dst, uint32_t size);
-
 
 #endif /* UTILITY_UTILS_H_ */

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ https://discord.gg/R6nZxZqDH3
 - Scheduler_run
 
 ## Utils
+- Utils_Memcpy
+- Utils_QuickUint32Pow10
 - Utils_StringToUint32
+- Utils_Strncmp
 - Utils_SwapElements
 
 - Utils_SerializeBlobBE

--- a/Src/priority_queue.c
+++ b/Src/priority_queue.c
@@ -34,7 +34,7 @@
 
 #include "priority_queue.h"
 
-#include <string.h>
+#include "utils.h"
 
 static bool
 IsPriorityQueueFull(const PriorityQueue_t* const queue) {
@@ -95,35 +95,25 @@ PriorityQueue_enqueue(PriorityQueue_t* const queue, const PriorityQueueItem_t* c
     bool status = false;
     if (!IsPriorityQueueFull(queue)) {
         uint8_t* buffer = queue->buffer;
-        if (memcpy(&buffer[queue->size * queue->element_size], item->element, queue->element_size) != NULL_PTR) {
-            queue->priority_array[queue->size] = *(item->priority);
-            queue->size = queue->size + 1U;
-            status = true;
-        }
+        Utils_Memcpy(&buffer[queue->size * queue->element_size], item->element, queue->element_size);
+        queue->priority_array[queue->size] = *(item->priority);
+        queue->size = queue->size + 1U;
+        status = true;
     } else {
         uint32_t lowest_priority_index = FindLowestPriorityIndex(queue);
         if (queue->priority_array[lowest_priority_index] < (*(item->priority))) {
-            status = true;
             uint8_t* buffer = queue->buffer;
             queue->size = queue->size - 1U;
             const uint32_t current_size = queue->size;
             for (uint32_t i = lowest_priority_index; i < current_size; ++i) {
-                if (memcpy(&buffer[i * queue->element_size], &buffer[(i * queue->element_size) + queue->element_size], queue->element_size) != NULL_PTR) {
-                    queue->priority_array[i] = queue->priority_array[i + 1U];
-                } else {
-                    status = false;
-                    break;
-                }
+                Utils_Memcpy(&buffer[i * queue->element_size], &buffer[(i * queue->element_size) + queue->element_size], queue->element_size);
+                queue->priority_array[i] = queue->priority_array[i + 1U];
             }
 
-            if (status == true) {
-                if (memcpy(&buffer[queue->size * queue->element_size], item->element, queue->element_size) != NULL_PTR) {
-                    queue->priority_array[queue->size] = *(item->priority);
-                    queue->size = queue->size + 1U;
-                } else {
-                    status = false;
-                }
-            }
+            Utils_Memcpy(&buffer[queue->size * queue->element_size], item->element, queue->element_size);
+            queue->priority_array[queue->size] = *(item->priority);
+            queue->size = queue->size + 1U;
+            status = true;
         }
     }
     return status;
@@ -135,19 +125,14 @@ PriorityQueue_dequeue(PriorityQueue_t* const queue, uint8_t* const element) {
     if (!PriorityQueue_isEmpty(queue)) {
         uint32_t highest_priority_index = FindHighestPriorityIndex(queue);
         uint8_t* buffer = queue->buffer;
-        if (memcpy(element, &buffer[highest_priority_index * queue->element_size], queue->element_size) != NULL_PTR) {
-            status = true;
-            queue->size = queue->size - 1U;
-            const uint32_t current_size = queue->size;
-            for (uint32_t i = highest_priority_index; i < current_size; ++i) {
-                if (memcpy(&buffer[i * queue->element_size], &buffer[(i * queue->element_size) + queue->element_size], queue->element_size) != NULL_PTR) {
-                    queue->priority_array[i] = queue->priority_array[i + 1U];
-                } else {
-                    status = false;
-                    break;
-                }
-            }
+        Utils_Memcpy(element, &buffer[highest_priority_index * queue->element_size], queue->element_size);
+        queue->size = queue->size - 1U;
+        const uint32_t current_size = queue->size;
+        for (uint32_t i = highest_priority_index; i < current_size; ++i) {
+            Utils_Memcpy(&buffer[i * queue->element_size], &buffer[(i * queue->element_size) + queue->element_size], queue->element_size);
+            queue->priority_array[i] = queue->priority_array[i + 1U];
         }
+        status = true;
     }
     return status;
 }

--- a/Src/queue.c
+++ b/Src/queue.c
@@ -34,7 +34,7 @@
 
 #include "queue.h"
 
-#include <string.h>
+#include "utils.h"
 
 bool
 Queue_initQueue(Queue_t* const queue, const uint32_t capacity, const uint32_t element_size, uint8_t* buffer) {
@@ -67,10 +67,9 @@ Queue_enqueue(Queue_t* const queue, const uint8_t* const element) {
     if (!Queue_isFull(queue)) {
         queue->rear = (queue->rear + 1U) % queue->capacity;
         uint8_t* buffer = queue->buffer;
-        if (memcpy(&buffer[queue->rear * queue->element_size], element, queue->element_size) != NULL_PTR) {
-            queue->size = queue->size + 1U;
-            status = true;
-        }
+        Utils_Memcpy(&buffer[queue->rear * queue->element_size], element, queue->element_size);
+        queue->size = queue->size + 1U;
+        status = true;
     }
     return status;
 }
@@ -80,11 +79,10 @@ Queue_dequeue(Queue_t* const queue, uint8_t* const element) {
     bool status = false;
     if (!Queue_isEmpty(queue)) {
         const uint8_t* buffer = (const uint8_t*)queue->buffer;
-        if (memcpy(element, &buffer[queue->front * queue->element_size], queue->element_size) != NULL_PTR) {
-            queue->front = (queue->front + 1U) % queue->capacity;
-            queue->size = queue->size - 1U;
-            status = true;
-        }
+        Utils_Memcpy(element, &buffer[queue->front * queue->element_size], queue->element_size);
+        queue->front = (queue->front + 1U) % queue->capacity;
+        queue->size = queue->size - 1U;
+        status = true;
     }
     return status;
 }
@@ -94,9 +92,8 @@ Queue_front(const Queue_t* const queue, uint8_t* const element) {
     bool status = false;
     if (!Queue_isEmpty(queue)) {
         const uint8_t* buffer = (const uint8_t*)queue->buffer;
-        if (memcpy(element, &buffer[queue->front * queue->element_size], queue->element_size) != NULL_PTR) {
-            status = true;
-        }
+        Utils_Memcpy(element, &buffer[queue->front * queue->element_size], queue->element_size);
+        status = true;
     }
     return status;
 }
@@ -106,9 +103,8 @@ Queue_rear(const Queue_t* const queue, uint8_t* const element) {
     bool status = false;
     if (!Queue_isEmpty(queue)) {
         const uint8_t* buffer = (const uint8_t*)queue->buffer;
-        if (memcpy(element, &buffer[queue->rear * queue->element_size], queue->element_size) != NULL_PTR) {
-            status = true;
-        }
+        Utils_Memcpy(element, &buffer[queue->rear * queue->element_size], queue->element_size);
+        status = true;
     }
     return status;
 }

--- a/Src/utils.c
+++ b/Src/utils.c
@@ -36,6 +36,13 @@
 
 #define MAX_UINT32_POW_10_EXPONENT 10U
 
+void
+Utils_Memcpy(uint8_t* to, const uint8_t* from, const uint32_t size) {
+    for (uint32_t i = 0U; i < size; ++i) {
+        to[i] = from[i];
+    }
+}
+
 bool
 Utils_QuickUint32Pow10(const uint8_t exponent, uint32_t* result) {
     bool success = false;

--- a/Tests/test_utils.c
+++ b/Tests/test_utils.c
@@ -22,6 +22,7 @@ TEST_TEAR_DOWN(Utils) {
 }
 
 TEST_GROUP_RUNNER(Utils) {
+    RUN_TEST_CASE(Utils, Utils_Memcpy);
     RUN_TEST_CASE(Utils, Utils_QuickUint32Pow10);
     RUN_TEST_CASE(Utils, Utils_StringToUint32);
     RUN_TEST_CASE(Utils, Utils_Strncmp);
@@ -32,6 +33,17 @@ TEST_GROUP_RUNNER(Utils) {
     RUN_TEST_CASE(Utils, Utils_DeserializeBlobLE);
     RUN_TEST_CASE(Utils, Utils_BigEndianSerializeDeserialize);
     RUN_TEST_CASE(Utils, Utils_LittleEndianSerializeDeserialize);
+}
+
+TEST(Utils, Utils_Memcpy) {
+    uint32_t result[5];
+    uint32_t expected[5] = {1U, 2U, 3U, 4U, 5U};
+
+    Utils_Memcpy((uint8_t*)&result, (uint8_t*)&expected, sizeof(expected));
+
+    for (uint8_t i = 0U; i < (sizeof(expected) / sizeof(expected[0])); ++i) {
+        TEST_ASSERT_EQUAL_UINT32(result[i], expected[i]);
+    }
 }
 
 TEST(Utils, Utils_QuickUint32Pow10) {
@@ -87,7 +99,6 @@ TEST(Utils, Utils_StringToUint32) {
 }
 
 TEST(Utils, Utils_Strncmp) {
-
     char str_base[] = "BSdasdasd!eienfef";
     char str_equal[] = "BSdasdasd!eienfef";
     TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_equal, strlen(str_base)), 0);


### PR DESCRIPTION
- implement Utils_Memcpy function
- fix violation of MISRA rule 21.18: The 'size_t' argument passed to any function in '<string.h>' shall have an appropriate value.

Edit[@Igor-Misic ]: see https://github.com/IMProject/IMUtility/pull/42 on how to properly solve these MISRA violations 