### PR TITLE
Implement Utils_Strcpy function + minor astlye change

### DIFF
--- a/Inc/bubble_sort.h
+++ b/Inc/bubble_sort.h
@@ -37,6 +37,7 @@
 
 #include "typedefs.h"
 
-void BubbleSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size, bool (*compareFun)(void* first, void* second));
+void BubbleSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
+                     bool (*compareFun)(void* first, void* second));
 
 #endif /* UTILITY_BUBBLE_SORT_H_ */

--- a/Inc/heap_sort.h
+++ b/Inc/heap_sort.h
@@ -37,6 +37,7 @@
 
 #include "typedefs.h"
 
-void HeapSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size, bool (*compareFun)(void* first, void* second));
+void HeapSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
+                   bool (*compareFun)(void* first, void* second));
 
 #endif /* UTILITY_HEAP_SORT_H_ */

--- a/Inc/json.h
+++ b/Inc/json.h
@@ -35,9 +35,9 @@
 #ifndef UTILITY_JSON_H_
 #define UTILITY_JSON_H_
 
-#include <stdint.h>
-#include <stdbool.h>
 #include <string.h>
+
+#include "typedefs.h"
 
 bool Json_startString(char* buffer, size_t buffer_size);
 bool Json_addData(char* buffer, size_t buffer_size, const char* key,  const char* value);

--- a/Inc/priority_queue.h
+++ b/Inc/priority_queue.h
@@ -50,7 +50,8 @@ typedef struct {
     uint8_t* buffer;
 } PriorityQueue_t;
 
-bool PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const uint32_t element_size, const PriorityQueueItem_t* items);
+bool PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const uint32_t element_size,
+                             const PriorityQueueItem_t* items);
 bool PriorityQueue_isEmpty(const PriorityQueue_t* const queue);
 bool PriorityQueue_enqueue(PriorityQueue_t* const queue, const PriorityQueueItem_t* const item);
 bool PriorityQueue_dequeue(PriorityQueue_t* const queue, uint8_t* const element);

--- a/Inc/utils.h
+++ b/Inc/utils.h
@@ -39,6 +39,7 @@
 
 void Utils_Memcpy(uint8_t* to, const uint8_t* from, const uint32_t size);
 bool Utils_QuickUint32Pow10(const uint8_t exponent, uint32_t* result);
+void Utils_Strcpy(char* to, const char* from);
 bool Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* integer);
 int32_t Utils_Strncmp(const char* str1, const char* str2, const uint32_t num);
 void Utils_SwapElements(uint8_t* first, uint8_t* second, const uint32_t size);

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ https://discord.gg/R6nZxZqDH3
 ## Utils
 - Utils_Memcpy
 - Utils_QuickUint32Pow10
+- Utils_Strcpy
 - Utils_StringToUint32
 - Utils_Strncmp
 - Utils_SwapElements

--- a/Src/bubble_sort.c
+++ b/Src/bubble_sort.c
@@ -37,7 +37,8 @@
 #include "utils.h"
 
 void
-BubbleSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size, bool (*compareFun)(void* first, void* second)) {
+BubbleSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
+                bool (*compareFun)(void* first, void* second)) {
     uint8_t* elements = buffer;
     for (int32_t i = 0; i < (number_of_elements - 1); ++i) {
         bool swapped = false;

--- a/Src/heap_sort.c
+++ b/Src/heap_sort.c
@@ -37,7 +37,8 @@
 #include "utils.h"
 
 static void
-Heapify(uint8_t* buffer, const int32_t n, const int32_t i, const uint32_t element_size, bool (*compareFun)(void* first, void* second)) {
+Heapify(uint8_t* buffer, const int32_t n, const int32_t i, const uint32_t element_size, bool (*compareFun)(void* first,
+        void* second)) {
     bool continue_iterating = true;
     int32_t index = i;
     uint8_t* elements = buffer;
@@ -47,7 +48,8 @@ Heapify(uint8_t* buffer, const int32_t n, const int32_t i, const uint32_t elemen
         int32_t left = (2 * index) + 1;
         int32_t right = (2 * index) + 2;
 
-        bool compare_ret_value = compareFun(&elements[left * (int32_t)element_size], &elements[largest * (int32_t)element_size]);
+        bool compare_ret_value = compareFun(&elements[left * (int32_t)element_size],
+                                            &elements[largest * (int32_t)element_size]);
 
         if ((left < n) && (compare_ret_value)) {
             largest = left;
@@ -69,7 +71,8 @@ Heapify(uint8_t* buffer, const int32_t n, const int32_t i, const uint32_t elemen
 }
 
 void
-HeapSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size, bool (*compareFun)(void* first, void* second)) {
+HeapSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
+              bool (*compareFun)(void* first, void* second)) {
     int32_t i;
     uint8_t* elements = buffer;
     for (i = (number_of_elements / 2) - 1; i >= 0; --i) {

--- a/Src/json.c
+++ b/Src/json.c
@@ -40,12 +40,10 @@
 
 bool
 Json_startString(char* buffer, size_t buffer_size) {
-
     bool success = false;
 
     if (buffer_size >= MINIMAL_SIZE) {
-        // cppcheck-suppress misra-c2012-17.7; return value is not used, not needed in this case
-        strcpy(&buffer[0], "{");
+        Utils_Strcpy(&buffer[0], "{");
         success = true;
     }
 
@@ -54,7 +52,6 @@ Json_startString(char* buffer, size_t buffer_size) {
 
 bool
 Json_addData(char* buffer, size_t buffer_size, const char* key,  const char* value) {
-
     bool success = false;
 
     size_t index = strlen(buffer);
@@ -62,27 +59,20 @@ Json_addData(char* buffer, size_t buffer_size, const char* key,  const char* val
     total_size += strlen("\"\":\"\"") + strlen(key) + strlen(value) + 1U;
 
     if (0 == strcmp(&buffer[index - 1U], "\"")) {
-        // cppcheck-suppress misra-c2012-17.7; return value is not used, not needed in this case
-        strcpy(&buffer[index], ",");
+        Utils_Strcpy(&buffer[index], ",");
         ++index;
     }
 
     if ((int32_t)total_size <= ((int32_t)buffer_size - (int32_t)index)) {
-
-        // cppcheck-suppress misra-c2012-17.7; return value is not used, not needed in this case
-        strcpy(&buffer[index], "\"");
+        Utils_Strcpy(&buffer[index], "\"");
         index += strlen("\"");
-        // cppcheck-suppress misra-c2012-17.7; return value is not used, not needed in this case
-        strcpy(&buffer[index], key);
+        Utils_Strcpy(&buffer[index], key);
         index += strlen(key);
-        // cppcheck-suppress misra-c2012-17.7; return value is not used, not needed in this case
-        strcpy(&buffer[index], "\":\"");
+        Utils_Strcpy(&buffer[index], "\":\"");
         index += strlen("\":\"");
-        // cppcheck-suppress misra-c2012-17.7; return value is not used, not needed in this case
-        strcpy(&buffer[index], value);
+        Utils_Strcpy(&buffer[index], value);
         index += strlen(value);
-        // cppcheck-suppress misra-c2012-17.7; return value is not used, not needed in this case
-        strcpy(&buffer[index], "\"");
+        Utils_Strcpy(&buffer[index], "\"");
 
         success = true;
     }
@@ -91,13 +81,11 @@ Json_addData(char* buffer, size_t buffer_size, const char* key,  const char* val
 }
 bool
 Json_endString(char* buffer, size_t buffer_size) {
-
     bool success = false;
 
     size_t index = strlen(buffer);
     if (buffer_size >= (MINIMAL_SIZE + index)) {
-        // cppcheck-suppress misra-c2012-17.7; return value is not used, not needed in this case
-        strcpy(&buffer[index], "}");
+        Utils_Strcpy(&buffer[index], "}");
         success = true;
     }
 

--- a/Src/priority_queue.c
+++ b/Src/priority_queue.c
@@ -72,7 +72,8 @@ FindLowestPriorityIndex(const PriorityQueue_t* const queue) {
 }
 
 bool
-PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const uint32_t element_size, const PriorityQueueItem_t* items) {
+PriorityQueue_initQueue(PriorityQueue_t* const queue, const uint32_t capacity, const uint32_t element_size,
+                        const PriorityQueueItem_t* items) {
     bool status = false;
     if (capacity != 0U) {
         queue->capacity = capacity;
@@ -106,7 +107,8 @@ PriorityQueue_enqueue(PriorityQueue_t* const queue, const PriorityQueueItem_t* c
             queue->size = queue->size - 1U;
             const uint32_t current_size = queue->size;
             for (uint32_t i = lowest_priority_index; i < current_size; ++i) {
-                Utils_Memcpy(&buffer[i * queue->element_size], &buffer[(i * queue->element_size) + queue->element_size], queue->element_size);
+                Utils_Memcpy(&buffer[i * queue->element_size], &buffer[(i * queue->element_size) + queue->element_size],
+                             queue->element_size);
                 queue->priority_array[i] = queue->priority_array[i + 1U];
             }
 
@@ -129,7 +131,8 @@ PriorityQueue_dequeue(PriorityQueue_t* const queue, uint8_t* const element) {
         queue->size = queue->size - 1U;
         const uint32_t current_size = queue->size;
         for (uint32_t i = highest_priority_index; i < current_size; ++i) {
-            Utils_Memcpy(&buffer[i * queue->element_size], &buffer[(i * queue->element_size) + queue->element_size], queue->element_size);
+            Utils_Memcpy(&buffer[i * queue->element_size], &buffer[(i * queue->element_size) + queue->element_size],
+                         queue->element_size);
             queue->priority_array[i] = queue->priority_array[i + 1U];
         }
         status = true;

--- a/Src/utils.c
+++ b/Src/utils.c
@@ -60,6 +60,17 @@ Utils_QuickUint32Pow10(const uint8_t exponent, uint32_t* result) {
     return success;
 }
 
+void
+Utils_Strcpy(char* to, const char* from) {
+    uint32_t i = 0U;
+    while (from[i] != '\0') {
+        to[i] = from[i];
+        ++i;
+    }
+
+    to[i] = '\0';
+}
+
 bool
 Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* integer) {
     bool success = true;

--- a/Tests/test_bubble_sort.c
+++ b/Tests/test_bubble_sort.c
@@ -22,7 +22,8 @@ TEST_GROUP_RUNNER(BubbleSort) {
 TEST(BubbleSort, BubbleSort_int32) {
     int32_t unsorted_array[] = {5, 2, 3, 1000000, 9, 10, 11, 8, 9, 100};
     const int32_t sorted_array[] = {2, 3, 5, 8, 9, 9, 10, 11, 100, 1000000};
-    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareInt32);
+    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+                    CompareInt32);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
         TEST_ASSERT_EQUAL_INT32(unsorted_array[i], sorted_array[i]);
@@ -32,7 +33,8 @@ TEST(BubbleSort, BubbleSort_int32) {
 TEST(BubbleSort, BubbleSort_float64) {
     float64_t unsorted_array[] = {5.8, 2.2, 3.1, 1.1, 9.1, 10.3, 11.2, 8.4, 9.2, 100.9};
     const float64_t sorted_array[] = {1.1, 2.2, 3.1, 5.8, 8.4, 9.1, 9.2, 10.3, 11.2, 100.9};
-    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareFloat64);
+    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+                    CompareFloat64);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
         TEST_ASSERT_EQUAL_DOUBLE(unsorted_array[i], sorted_array[i]);
@@ -42,7 +44,8 @@ TEST(BubbleSort, BubbleSort_float64) {
 TEST(BubbleSort, BubbleSort_uint64) {
     uint64_t unsorted_array[] = {1111111U, 55555555U, 44444U, 10000000000000U, 212121U, 1111U, 1U, 2U, 5U, 3U};
     const uint64_t sorted_array[] = {1U, 2U, 3U, 5U, 1111U, 44444U, 212121U, 1111111U, 55555555U, 10000000000000U};
-    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareUint64);
+    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+                    CompareUint64);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
         TEST_ASSERT_EQUAL_UINT64(unsorted_array[i], sorted_array[i]);

--- a/Tests/test_crc32.c
+++ b/Tests/test_crc32.c
@@ -29,41 +29,69 @@ TEST_GROUP_RUNNER(Crc32) {
 }
 
 TEST(Crc32, CalculateCRC32_Reflect_output_and_input) {
-    TEST_ASSERT_EQUAL_HEX32(0x2144DF1CU, CalculateCRC32(message1, sizeof(message1), init_value, crc_xor_value, true, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0x24AB9D77U, CalculateCRC32(message2, sizeof(message2), init_value, crc_xor_value, true, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0xB6C9B287U, CalculateCRC32(message3, sizeof(message3), init_value, crc_xor_value, true, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0x32A06212U, CalculateCRC32(message4, sizeof(message4), init_value, crc_xor_value, true, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0xB0AE863DU, CalculateCRC32(message5, sizeof(message5), init_value, crc_xor_value, true, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0x9CDEA29BU, CalculateCRC32(message6, sizeof(message6), init_value, crc_xor_value, true, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFU, CalculateCRC32(message7, sizeof(message7), init_value, crc_xor_value, true, true, true));
+    TEST_ASSERT_EQUAL_HEX32(0x2144DF1CU, CalculateCRC32(message1, sizeof(message1), init_value, crc_xor_value, true, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0x24AB9D77U, CalculateCRC32(message2, sizeof(message2), init_value, crc_xor_value, true, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xB6C9B287U, CalculateCRC32(message3, sizeof(message3), init_value, crc_xor_value, true, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0x32A06212U, CalculateCRC32(message4, sizeof(message4), init_value, crc_xor_value, true, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xB0AE863DU, CalculateCRC32(message5, sizeof(message5), init_value, crc_xor_value, true, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0x9CDEA29BU, CalculateCRC32(message6, sizeof(message6), init_value, crc_xor_value, true, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFU, CalculateCRC32(message7, sizeof(message7), init_value, crc_xor_value, true, true,
+                            true));
 }
 
 TEST(Crc32, CalculateCRC32_Reflect_input) {
-    TEST_ASSERT_EQUAL_HEX32(0x38FB2284U, CalculateCRC32(message1, sizeof(message1), init_value, crc_xor_value, false, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0xEEB9D524U, CalculateCRC32(message2, sizeof(message2), init_value, crc_xor_value, false, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0xE14D936DU, CalculateCRC32(message3, sizeof(message3), init_value, crc_xor_value, false, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0x4846054CU, CalculateCRC32(message4, sizeof(message4), init_value, crc_xor_value, false, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0xBC61750DU, CalculateCRC32(message5, sizeof(message5), init_value, crc_xor_value, false, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0xD9457B39U, CalculateCRC32(message6, sizeof(message6), init_value, crc_xor_value, false, true, true));
-    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFU, CalculateCRC32(message7, sizeof(message7), init_value, crc_xor_value, false, true, true));
+    TEST_ASSERT_EQUAL_HEX32(0x38FB2284U, CalculateCRC32(message1, sizeof(message1), init_value, crc_xor_value, false, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xEEB9D524U, CalculateCRC32(message2, sizeof(message2), init_value, crc_xor_value, false, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xE14D936DU, CalculateCRC32(message3, sizeof(message3), init_value, crc_xor_value, false, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0x4846054CU, CalculateCRC32(message4, sizeof(message4), init_value, crc_xor_value, false, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xBC61750DU, CalculateCRC32(message5, sizeof(message5), init_value, crc_xor_value, false, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xD9457B39U, CalculateCRC32(message6, sizeof(message6), init_value, crc_xor_value, false, true,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFU, CalculateCRC32(message7, sizeof(message7), init_value, crc_xor_value, false, true,
+                            true));
 }
 
 TEST(Crc32, CalculateCRC32_Reflect_output) {
-    TEST_ASSERT_EQUAL_HEX32(0x2144DF1CU, CalculateCRC32(message1, sizeof(message1), init_value, crc_xor_value, true, false, true));
-    TEST_ASSERT_EQUAL_HEX32(0x53677982U, CalculateCRC32(message2, sizeof(message2), init_value, crc_xor_value, true, false, true));
-    TEST_ASSERT_EQUAL_HEX32(0xFB566F16U, CalculateCRC32(message3, sizeof(message3), init_value, crc_xor_value, true, false, true));
-    TEST_ASSERT_EQUAL_HEX32(0x2857B480U, CalculateCRC32(message4, sizeof(message4), init_value, crc_xor_value, true, false, true));
-    TEST_ASSERT_EQUAL_HEX32(0xBD39C06BU, CalculateCRC32(message5, sizeof(message5), init_value, crc_xor_value, true, false, true));
-    TEST_ASSERT_EQUAL_HEX32(0x616B4732U, CalculateCRC32(message6, sizeof(message6), init_value, crc_xor_value, true, false, true));
-    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFU, CalculateCRC32(message7, sizeof(message7), init_value, crc_xor_value, true, false, true));
+    TEST_ASSERT_EQUAL_HEX32(0x2144DF1CU, CalculateCRC32(message1, sizeof(message1), init_value, crc_xor_value, true, false,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0x53677982U, CalculateCRC32(message2, sizeof(message2), init_value, crc_xor_value, true, false,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xFB566F16U, CalculateCRC32(message3, sizeof(message3), init_value, crc_xor_value, true, false,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0x2857B480U, CalculateCRC32(message4, sizeof(message4), init_value, crc_xor_value, true, false,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xBD39C06BU, CalculateCRC32(message5, sizeof(message5), init_value, crc_xor_value, true, false,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0x616B4732U, CalculateCRC32(message6, sizeof(message6), init_value, crc_xor_value, true, false,
+                            true));
+    TEST_ASSERT_EQUAL_HEX32(0xFFFFFFFFU, CalculateCRC32(message7, sizeof(message7), init_value, crc_xor_value, true, false,
+                            true));
 }
 
 TEST(Crc32, CalculateCRC32_Without_finish_xor) {
-    TEST_ASSERT_EQUAL_HEX32(0xDEBB20E3U, CalculateCRC32(message1, sizeof(message1), init_value, crc_xor_value, true, true, false));
-    TEST_ASSERT_EQUAL_HEX32(0xDB546288U, CalculateCRC32(message2, sizeof(message2), init_value, crc_xor_value, true, true, false));
-    TEST_ASSERT_EQUAL_HEX32(0x49364D78U, CalculateCRC32(message3, sizeof(message3), init_value, crc_xor_value, true, true, false));
-    TEST_ASSERT_EQUAL_HEX32(0xCD5F9DEDU, CalculateCRC32(message4, sizeof(message4), init_value, crc_xor_value, true, true, false));
-    TEST_ASSERT_EQUAL_HEX32(0x4F5179C2U, CalculateCRC32(message5, sizeof(message5), init_value, crc_xor_value, true, true, false));
-    TEST_ASSERT_EQUAL_HEX32(0x63215D64U, CalculateCRC32(message6, sizeof(message6), init_value, crc_xor_value, true, true, false));
-    TEST_ASSERT_EQUAL_HEX32(0x00000000U, CalculateCRC32(message7, sizeof(message7), init_value, crc_xor_value, true, true, false));
+    TEST_ASSERT_EQUAL_HEX32(0xDEBB20E3U, CalculateCRC32(message1, sizeof(message1), init_value, crc_xor_value, true, true,
+                            false));
+    TEST_ASSERT_EQUAL_HEX32(0xDB546288U, CalculateCRC32(message2, sizeof(message2), init_value, crc_xor_value, true, true,
+                            false));
+    TEST_ASSERT_EQUAL_HEX32(0x49364D78U, CalculateCRC32(message3, sizeof(message3), init_value, crc_xor_value, true, true,
+                            false));
+    TEST_ASSERT_EQUAL_HEX32(0xCD5F9DEDU, CalculateCRC32(message4, sizeof(message4), init_value, crc_xor_value, true, true,
+                            false));
+    TEST_ASSERT_EQUAL_HEX32(0x4F5179C2U, CalculateCRC32(message5, sizeof(message5), init_value, crc_xor_value, true, true,
+                            false));
+    TEST_ASSERT_EQUAL_HEX32(0x63215D64U, CalculateCRC32(message6, sizeof(message6), init_value, crc_xor_value, true, true,
+                            false));
+    TEST_ASSERT_EQUAL_HEX32(0x00000000U, CalculateCRC32(message7, sizeof(message7), init_value, crc_xor_value, true, true,
+                            false));
 }

--- a/Tests/test_heap_sort.c
+++ b/Tests/test_heap_sort.c
@@ -22,7 +22,8 @@ TEST_GROUP_RUNNER(HeapSort) {
 TEST(HeapSort, HeapSort_int32) {
     int32_t unsorted_array[] = {5, 2, 3, 1000000, 9, 10, 11, 8, 9, 100};
     const int32_t sorted_array[] = {2, 3, 5, 8, 9, 9, 10, 11, 100, 1000000};
-    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareInt32);
+    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+                  CompareInt32);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
         TEST_ASSERT_EQUAL_INT32(unsorted_array[i], sorted_array[i]);
@@ -32,7 +33,8 @@ TEST(HeapSort, HeapSort_int32) {
 TEST(HeapSort, HeapSort_float64) {
     float64_t unsorted_array[] = {5.8, 2.2, 3.1, 1.1, 9.1, 10.3, 11.2, 8.4, 9.2, 100.9};
     const float64_t sorted_array[] = {1.1, 2.2, 3.1, 5.8, 8.4, 9.1, 9.2, 10.3, 11.2, 100.9};
-    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareFloat64);
+    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+                  CompareFloat64);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
         TEST_ASSERT_EQUAL_DOUBLE(unsorted_array[i], sorted_array[i]);
@@ -42,7 +44,8 @@ TEST(HeapSort, HeapSort_float64) {
 TEST(HeapSort, HeapSort_uint64) {
     uint64_t unsorted_array[] = {1111111U, 55555555U, 44444U, 10000000000000U, 212121U, 1111U, 1U, 2U, 5U, 3U};
     const uint64_t sorted_array[] = {1U, 2U, 3U, 5U, 1111U, 44444U, 212121U, 1111111U, 55555555U, 10000000000000U};
-    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]), CompareUint64);
+    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+                  CompareUint64);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
         TEST_ASSERT_EQUAL_UINT64(unsorted_array[i], sorted_array[i]);

--- a/Tests/test_json.c
+++ b/Tests/test_json.c
@@ -60,7 +60,8 @@ TEST(Json, Json_findByKey) {
 
         char key_2[] = "public_key_signature";
         success = Json_findByKey(json_string, strlen(json_string), key_2, value, size);
-        TEST_ASSERT_EQUAL_STRING("sQjximnEuRAsf+mAuTURcXASUS5vkl5xU0SNvvAcX+Mfc7es+xXw/Lgo0bfMNY+ShKe5VjbIg3DaSxJvLbhX+w==", value);
+        TEST_ASSERT_EQUAL_STRING("sQjximnEuRAsf+mAuTURcXASUS5vkl5xU0SNvvAcX+Mfc7es+xXw/Lgo0bfMNY+ShKe5VjbIg3DaSxJvLbhX+w==",
+                                 value);
         TEST_ASSERT_EQUAL_INT(true, success);
 
 

--- a/Tests/test_utils.c
+++ b/Tests/test_utils.c
@@ -24,6 +24,7 @@ TEST_TEAR_DOWN(Utils) {
 TEST_GROUP_RUNNER(Utils) {
     RUN_TEST_CASE(Utils, Utils_Memcpy);
     RUN_TEST_CASE(Utils, Utils_QuickUint32Pow10);
+    RUN_TEST_CASE(Utils, Utils_Strcpy);
     RUN_TEST_CASE(Utils, Utils_StringToUint32);
     RUN_TEST_CASE(Utils, Utils_Strncmp);
     RUN_TEST_CASE(Utils, Utils_SwapElements);
@@ -65,6 +66,15 @@ TEST(Utils, Utils_QuickUint32Pow10) {
     }
 
     TEST_ASSERT_FALSE(Utils_QuickUint32Pow10(10U, &result));
+}
+
+TEST(Utils, Utils_Strcpy) {
+    const char from[5] = "hehe";
+    char to[5];
+
+    Utils_Strcpy(to, from);
+
+    TEST_ASSERT_EQUAL_STRING(to, from);
 }
 
 TEST(Utils, Utils_StringToUint32) {

--- a/Tests/test_utils.c
+++ b/Tests/test_utils.c
@@ -98,10 +98,12 @@ TEST(Utils, Utils_StringToUint32) {
     TEST_ASSERT_EQUAL_UINT32(ui32_number, 4294967295U);
 
     char overflow_1_uint32_number_string[] = "4294967296";
-    TEST_ASSERT_FALSE(Utils_StringToUint32(overflow_1_uint32_number_string, strlen(overflow_1_uint32_number_string), &ui32_number));
+    TEST_ASSERT_FALSE(Utils_StringToUint32(overflow_1_uint32_number_string, strlen(overflow_1_uint32_number_string),
+                                           &ui32_number));
 
     char overflow_2_uint32_number_string[] = "5294967295";
-    TEST_ASSERT_FALSE(Utils_StringToUint32(overflow_2_uint32_number_string, strlen(overflow_2_uint32_number_string), &ui32_number));
+    TEST_ASSERT_FALSE(Utils_StringToUint32(overflow_2_uint32_number_string, strlen(overflow_2_uint32_number_string),
+                                           &ui32_number));
 
     char not_a_number_string[] = "A";
     TEST_ASSERT_FALSE(Utils_StringToUint32(not_a_number_string, strlen(not_a_number_string), &ui32_number));

--- a/Tools/astyle/astylerc
+++ b/Tools/astyle/astylerc
@@ -24,9 +24,8 @@ add-one-line-braces
 break-return-type
 
 convert-tabs
-max-code-length=200
+max-code-length=120
 min-conditional-indent=0
-max-continuation-indent=120
 
 attach-closing-while
 


### PR DESCRIPTION
- add Utils_Strcpy function
- Fix violation of MISRA rule 19.1: An object shall not be assigned or copied to an overlapping object.
- minor astyle change - change max code length to 120

Edit [@Igor-Misic ]:
No proper way of fixing MISRA rule 19.1, see: https://github.com/IMProject/IMUtility/pull/39