### PR TITLE
Fix cppcheck warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,8 @@ cppcheck:
 	
 misra:
 	$(call colorecho,'Checking MISRA C:2012 with cppcheck')
-	@cppcheck cppcheck -IInc Src --force --addon=misra.py --inline-suppr --suppress=misra-c2012-2.3 --error-exitcode=1
+	@cppcheck cppcheck -IInc Src --force --addon=misra.py --inline-suppr --suppress=misra-c2012-2.3 \
+	 --suppress=misra-c2012-8.4 --suppress=misra-c2012-8.7 --error-exitcode=1
 	
 #######################################
 # Unit test

--- a/Src/base64.c
+++ b/Src/base64.c
@@ -41,20 +41,19 @@ Base64_encode(const char* data, size_t data_length, char* result, size_t max_res
         (uint8_t)'\0'
     };
     uint8_t* out;
-    uint8_t* pos;
     const uint8_t* in = (const uint8_t*) data;
 
     size_t len = 4U * ((data_length + 2U) / 3U);
-    size_t current_length = 0U;
-    size_t in_position = 0U;
 
     if (len < data_length) {
         success = 1;
     }
 
     if (success == 0) {
+        size_t current_length = 0U;
+        size_t in_position = 0U;
         out = (uint8_t*)&result[0];
-        pos = out;
+        uint8_t* pos = out;
         while ((data_length - in_position) >= 3U) {
             current_length += 4U;
             if (current_length > max_result_length) {

--- a/Tests/test_priority_queue.c
+++ b/Tests/test_priority_queue.c
@@ -37,10 +37,10 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32) {
     uint32_t priority;
     item.priority = &priority;
     for (i = 0U; i < capacity; ++i) {
-        priority = 1U;
+        *(item.priority) = 1U;
         item.element = (uint8_t*)&i;
         if (i == 50U) {
-            priority = 2U;
+            *(item.priority) = 2U;
         }
         TEST_ASSERT_TRUE(PriorityQueue_enqueue(&queue, &item));
     }
@@ -50,7 +50,7 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_uint32) {
     TEST_ASSERT_FALSE(PriorityQueue_enqueue(&queue, &item));
 
     // add element with higher priority than the current lowest priority
-    priority = 9U;
+    *(item.priority) = 9U;
     TEST_ASSERT_TRUE(PriorityQueue_enqueue(&queue, &item));
 
     // dequeue
@@ -82,9 +82,9 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_float32_t) {
     item.element = (uint8_t*)&element;
     element = 0.0F;
     for (i = 0U; i < capacity; ++i) {
-        priority = 1U;
+        *(item.priority) = 1U;
         if (i == 50U) {
-            priority = 2U;
+            *(item.priority) = 2U;
         }
         TEST_ASSERT_TRUE(PriorityQueue_enqueue(&queue, &item));
         element += 1.0F;
@@ -95,7 +95,7 @@ TEST(PriorityQueue, PriorityQueue_enqueue_dequeue_float32_t) {
     TEST_ASSERT_FALSE(PriorityQueue_enqueue(&queue, &item));
 
     // add element with higher priority than the current lowest priority
-    priority = 9U;
+    *(item.priority) = 9U;
     TEST_ASSERT_TRUE(PriorityQueue_enqueue(&queue, &item));
 
     // dequeue


### PR DESCRIPTION
- The scope of the variable can be reduced. [variableScope]
- Variable is reassigned a value before the old one has been used. [redundantAssignment]
- suppress cppcheck MISRA rules 8.4 and 8.7