### PR TITLE
Revert to strncmp from <string.h>

### DIFF
--- a/Inc/utils.h
+++ b/Inc/utils.h
@@ -40,7 +40,6 @@
 void Utils_Memcpy(uint8_t* to, const uint8_t* from, const uint32_t size);
 bool Utils_QuickUint32Pow10(const uint8_t exponent, uint32_t* result);
 bool Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* integer);
-int32_t Utils_Strncmp(const char* str1, const char* str2, const uint32_t num);
 void Utils_SwapElements(uint8_t* first, uint8_t* second, const uint32_t size);
 
 // Big-endian

--- a/Src/json.c
+++ b/Src/json.c
@@ -106,14 +106,19 @@ bool
 Json_findByKey(const char* buffer, size_t buffer_size, const char* key, char* value, size_t max_value_size) {
     bool success = false;
 
-    uint32_t max_search_size = (uint32_t)(buffer_size - strlen(key));
-
+    size_t key_size = strlen(key);
+    uint32_t max_search_size = 0U;
     uint32_t index;
-    uint32_t key_size = (uint32_t)strlen(key);
 
-    for (index = 0; index < max_search_size; ++index) {
+    if (buffer_size > key_size) {
+        max_search_size = (uint32_t)(buffer_size - key_size);
+    }
 
-        if (0 == Utils_Strncmp(&buffer[index], key, key_size)) {
+    for (index = 0U; index < max_search_size; ++index) {
+
+        /* -E> compliant MC3R1.R21.18 2 strncmp is guarded in for loop condition to not go out of buffer boundaries
+        by calculating max_search_size from buffer size and key size */
+        if (0 == strncmp(&buffer[index], key, key_size)) {
 
             if (buffer[index + key_size] == '"') {
                 success = true;

--- a/Src/utils.c
+++ b/Src/utils.c
@@ -112,22 +112,6 @@ Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* intege
     return success;
 }
 
-int32_t
-Utils_Strncmp(const char* str1, const char* str2, const uint32_t num) {
-
-    int32_t ret_val = 0;
-
-    for (uint32_t i = 0U; (i < num) && (str1[i] != '\0') && (str2[i] != '\0'); ++i) {
-
-        if (str1[i] != str2[i]) {
-            ret_val = str1[i] - str2[i];
-            break;
-        }
-    }
-
-    return ret_val;
-}
-
 void
 Utils_SwapElements(uint8_t* first, uint8_t* second, const uint32_t size) {
     uint8_t* first_element = first;

--- a/Tests/test_json.c
+++ b/Tests/test_json.c
@@ -54,33 +54,31 @@ TEST(Json, Json_findByKey) {
         size_t size = 200;
 
         char key_1[] = "public_key";
-        bool success = Json_findByKey(json_string, strlen(json_string), key_1, value, size);
+        TEST_ASSERT_TRUE(Json_findByKey(json_string, strlen(json_string), key_1, value, size));
         TEST_ASSERT_EQUAL_STRING("u1zeY+TBbtYlDIzZsLH16RJ9aIBmxTINpLXSkTpaikQ=", value);
-        TEST_ASSERT_EQUAL_INT(true, success);
 
         char key_2[] = "public_key_signature";
-        success = Json_findByKey(json_string, strlen(json_string), key_2, value, size);
+        TEST_ASSERT_TRUE(Json_findByKey(json_string, strlen(json_string), key_2, value, size));
         TEST_ASSERT_EQUAL_STRING("sQjximnEuRAsf+mAuTURcXASUS5vkl5xU0SNvvAcX+Mfc7es+xXw/Lgo0bfMNY+ShKe5VjbIg3DaSxJvLbhX+w==",
                                  value);
-        TEST_ASSERT_EQUAL_INT(true, success);
-
 
         char key_3[] = "public";
-        success = Json_findByKey(json_string, strlen(json_string), key_3, value, size);
-        TEST_ASSERT_EQUAL_INT(false, success);
+        TEST_ASSERT_FALSE(Json_findByKey(json_string, strlen(json_string), key_3, value, size));
 
         char key_4[] = "\"public_key\"";
-        success = Json_findByKey(json_string, strlen(json_string), key_4, value, size);
-        TEST_ASSERT_EQUAL_INT(false, success);
+        TEST_ASSERT_FALSE(Json_findByKey(json_string, strlen(json_string), key_4, value, size));
 
         size = 45; // 44 + '/0' needed for full string
-        success = Json_findByKey(json_string, strlen(json_string), key_1, value, size);
+        TEST_ASSERT_TRUE(Json_findByKey(json_string, strlen(json_string), key_1, value, size));
         TEST_ASSERT_EQUAL_STRING("u1zeY+TBbtYlDIzZsLH16RJ9aIBmxTINpLXSkTpaikQ=", value);
-        TEST_ASSERT_EQUAL_INT(true, success);
 
         size = 44; // can't fit full string
-        success = Json_findByKey(json_string, strlen(json_string), key_1, value, size);
+        TEST_ASSERT_FALSE(Json_findByKey(json_string, strlen(json_string), key_1, value, size));
         TEST_ASSERT_EQUAL_STRING("u1zeY+TBbtYlDIzZsLH16RJ9aIBmxTINpLXSkTpaikQ=", value);
-        TEST_ASSERT_EQUAL_INT(false, success);
+
+        char key_same_size_as_buffer[strlen(json_string) + 1];
+        memset(key_same_size_as_buffer, 'A', sizeof(key_same_size_as_buffer));
+        key_same_size_as_buffer[strlen(json_string)] = '\0';
+        TEST_ASSERT_FALSE(Json_findByKey(json_string, strlen(json_string), key_same_size_as_buffer, value, size));
     }
 }

--- a/Tests/test_utils.c
+++ b/Tests/test_utils.c
@@ -25,7 +25,6 @@ TEST_GROUP_RUNNER(Utils) {
     RUN_TEST_CASE(Utils, Utils_Memcpy);
     RUN_TEST_CASE(Utils, Utils_QuickUint32Pow10);
     RUN_TEST_CASE(Utils, Utils_StringToUint32);
-    RUN_TEST_CASE(Utils, Utils_Strncmp);
     RUN_TEST_CASE(Utils, Utils_SwapElements);
     RUN_TEST_CASE(Utils, Utils_SerializeBlobBE);
     RUN_TEST_CASE(Utils, Utils_Serialize32BE);
@@ -106,24 +105,6 @@ TEST(Utils, Utils_StringToUint32) {
 
     char not_a_number_4_string[] = "429496729A";
     TEST_ASSERT_FALSE(Utils_StringToUint32(not_a_number_4_string, strlen(not_a_number_4_string), &ui32_number));
-}
-
-TEST(Utils, Utils_Strncmp) {
-    char str_base[] = "BSdasdasd!eienfef";
-    char str_equal[] = "BSdasdasd!eienfef";
-    TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_equal, strlen(str_base)), 0);
-
-    char str_first_char_diff1[] = "ASdasdasd!eienfef";
-    TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_first_char_diff1, strlen(str_base)), 1);
-
-    char str_first_char_diff2[] = "CSdasdasd!eienfef";
-    TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_first_char_diff2, strlen(str_base)), -1);
-
-    char str_shorter_than_base[] = "BSda";
-    TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_shorter_than_base, strlen(str_base)), 0);
-
-    char str_longer_than_base[] = "BSdasdasd!eienfefAA";
-    TEST_ASSERT_EQUAL_INT32(Utils_Strncmp(str_base, str_longer_than_base, strlen(str_base)), 0);
 }
 
 TEST(Utils, Utils_SwapElements) {


### PR DESCRIPTION
It is better to suppress strncmp violation warning with an explanation of how we prevent a possible problem than write our own function to avoid the MISRA code analyzer catching it. 