### PR TITLE
Add type byte_t to follow Strict Aliasing Rule

### DIFF
--- a/Inc/bubble_sort.h
+++ b/Inc/bubble_sort.h
@@ -37,7 +37,7 @@
 
 #include "typedefs.h"
 
-void BubbleSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
+void BubbleSort_sort(byte_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
                      bool (*compareFun)(void* first, void* second));
 
 #endif /* UTILITY_BUBBLE_SORT_H_ */

--- a/Inc/heap_sort.h
+++ b/Inc/heap_sort.h
@@ -37,7 +37,7 @@
 
 #include "typedefs.h"
 
-void HeapSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
+void HeapSort_sort(byte_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
                    bool (*compareFun)(void* first, void* second));
 
 #endif /* UTILITY_HEAP_SORT_H_ */

--- a/Inc/typedefs.h
+++ b/Inc/typedefs.h
@@ -44,4 +44,8 @@ typedef float float32_t;
 typedef double float64_t;
 typedef long double float128_t;
 
+/* -E> compliant MC3R1.D4.6 2 Type byte_t shall be used everywhere where a pointer to bytes is needed to follow Strict Aliasing Rule */
+// More on the topic can be found here: https://gist.github.com/jibsen/da6be27cde4d526ee564
+typedef unsigned char byte_t;
+
 #endif /* UTILITY_TYPEDEFS_H_ */

--- a/Inc/utils.h
+++ b/Inc/utils.h
@@ -39,22 +39,22 @@
 
 bool Utils_QuickUint32Pow10(const uint8_t exponent, uint32_t* result);
 bool Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* integer);
-void Utils_SwapElements(uint8_t* first, uint8_t* second, const uint32_t size);
+void Utils_SwapElements(byte_t* first, byte_t* second, const uint32_t size);
 
 // Big-endian
-void Utils_SerializeBlobBE(uint8_t* buf, const uint8_t* src, uint32_t size);
-void Utils_Serialize32BE(uint8_t* buf, uint32_t value);
-void Utils_Serialize24BE(uint8_t* buf, uint32_t value);
-void Utils_Serialize16BE(uint8_t* buf, uint16_t value);
-void Utils_Serialize8BE(uint8_t* buf, uint8_t value);
-void Utils_DeserializeBlobBE(const uint8_t* buf, uint8_t* dst, uint32_t size);
-void Utils_Deserialize32BE(const uint8_t* buf, uint32_t* value);
-void Utils_Deserialize24BE(const uint8_t* buf, uint32_t* value);
-void Utils_Deserialize16BE(const uint8_t* buf, uint16_t* value);
-void Utils_Deserialize8BE(const uint8_t* buf, uint8_t* value);
+void Utils_SerializeBlobBE(byte_t* buf, const byte_t* src, uint32_t size);
+void Utils_Serialize32BE(byte_t* buf, uint32_t value);
+void Utils_Serialize24BE(byte_t* buf, uint32_t value);
+void Utils_Serialize16BE(byte_t* buf, uint16_t value);
+void Utils_Serialize8BE(byte_t* buf, uint8_t value);
+void Utils_DeserializeBlobBE(const byte_t* buf, byte_t* dst, uint32_t size);
+void Utils_Deserialize32BE(const byte_t* buf, uint32_t* value);
+void Utils_Deserialize24BE(const byte_t* buf, uint32_t* value);
+void Utils_Deserialize16BE(const byte_t* buf, uint16_t* value);
+void Utils_Deserialize8BE(const byte_t* buf, uint8_t* value);
 
 // Little-endian
-void Utils_SerializeBlobLE(uint8_t* buf, const uint8_t* src, uint32_t size);
-void Utils_DeserializeBlobLE(const uint8_t* buf, uint8_t* dst, uint32_t size);
+void Utils_SerializeBlobLE(byte_t* buf, const byte_t* src, uint32_t size);
+void Utils_DeserializeBlobLE(const byte_t* buf, byte_t* dst, uint32_t size);
 
 #endif /* UTILITY_UTILS_H_ */

--- a/Src/bubble_sort.c
+++ b/Src/bubble_sort.c
@@ -37,9 +37,9 @@
 #include "utils.h"
 
 void
-BubbleSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
+BubbleSort_sort(byte_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
                 bool (*compareFun)(void* first, void* second)) {
-    uint8_t* elements = buffer;
+    byte_t* elements = buffer;
     for (int32_t i = 0; i < (number_of_elements - 1); ++i) {
         bool swapped = false;
         for (int32_t j = 0; j < (number_of_elements - i - 1); ++j) {

--- a/Src/heap_sort.c
+++ b/Src/heap_sort.c
@@ -37,11 +37,11 @@
 #include "utils.h"
 
 static void
-Heapify(uint8_t* buffer, const int32_t n, const int32_t i, const uint32_t element_size, bool (*compareFun)(void* first,
-        void* second)) {
+Heapify(byte_t* buffer, const int32_t n, const int32_t i, const uint32_t element_size,
+        bool (*compareFun)(void* first, void* second)) {
     bool continue_iterating = true;
     int32_t index = i;
-    uint8_t* elements = buffer;
+    byte_t* elements = buffer;
 
     while (continue_iterating) {
         int32_t largest = index;
@@ -71,10 +71,10 @@ Heapify(uint8_t* buffer, const int32_t n, const int32_t i, const uint32_t elemen
 }
 
 void
-HeapSort_sort(uint8_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
+HeapSort_sort(byte_t* buffer, const int32_t number_of_elements, const uint32_t element_size,
               bool (*compareFun)(void* first, void* second)) {
     int32_t i;
-    uint8_t* elements = buffer;
+    byte_t* elements = buffer;
     for (i = (number_of_elements / 2) - 1; i >= 0; --i) {
         Heapify(elements, number_of_elements, i, element_size, compareFun);
     }

--- a/Src/utils.c
+++ b/Src/utils.c
@@ -106,26 +106,26 @@ Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* intege
 }
 
 void
-Utils_SwapElements(uint8_t* first, uint8_t* second, const uint32_t size) {
-    uint8_t* first_element = first;
-    uint8_t* second_element = second;
+Utils_SwapElements(byte_t* first, byte_t* second, const uint32_t size) {
+    byte_t* first_element = first;
+    byte_t* second_element = second;
     uint32_t index = size;
     while ((index--) != 0U) {
-        uint8_t temp = first_element[index];
+        byte_t temp = first_element[index];
         first_element[index] = second_element[index];
         second_element[index] = temp;
     }
 }
 
 void
-Utils_SerializeBlobBE(uint8_t* buf, const uint8_t* src, uint32_t size) {
+Utils_SerializeBlobBE(byte_t* buf, const byte_t* src, uint32_t size) {
     for (uint32_t i = 0; i < size; i++) {
         buf[i] = src[i];
     }
 }
 
 void
-Utils_Serialize32BE(uint8_t* buf, uint32_t value) {
+Utils_Serialize32BE(byte_t* buf, uint32_t value) {
     buf[0] = (uint8_t)(value >> 24u) & 0xFFu;
     buf[1] = (uint8_t)(value >> 16u) & 0xFFu;
     buf[2] = (uint8_t)(value >> 8u) & 0xFFu;
@@ -133,32 +133,32 @@ Utils_Serialize32BE(uint8_t* buf, uint32_t value) {
 }
 
 void
-Utils_Serialize24BE(uint8_t* buf, uint32_t value) {
+Utils_Serialize24BE(byte_t* buf, uint32_t value) {
     buf[0] = (uint8_t)(value >> 16u) & 0xFFu;
     buf[1] = (uint8_t)(value >> 8u) & 0xFFu;
     buf[2] = (uint8_t)(value) & 0xFFu;
 }
 
 void
-Utils_Serialize16BE(uint8_t* buf, uint16_t value) {
+Utils_Serialize16BE(byte_t* buf, uint16_t value) {
     buf[0] = (uint8_t)(value >> 8u) & 0xFFu;
     buf[1] = (uint8_t)(value) & 0xFFu;
 }
 
 void
-Utils_Serialize8BE(uint8_t* buf, uint8_t value) {
+Utils_Serialize8BE(byte_t* buf, uint8_t value) {
     buf[0] = (uint8_t)(value) & 0xFFu;
 }
 
 void
-Utils_DeserializeBlobBE(const uint8_t* buf, uint8_t* dst, uint32_t size) {
+Utils_DeserializeBlobBE(const byte_t* buf, byte_t* dst, uint32_t size) {
     for (uint32_t i = 0; i < size; i++) {
         dst[i] = buf[i];
     }
 }
 
 void
-Utils_SerializeBlobLE(uint8_t* buf, const uint8_t* src, uint32_t size) {
+Utils_SerializeBlobLE(byte_t* buf, const byte_t* src, uint32_t size) {
     int32_t j = 0;
     for (int32_t i = ((int32_t)size - 1); i >= 0; --i) {
         buf[j] = src[i];
@@ -167,7 +167,7 @@ Utils_SerializeBlobLE(uint8_t* buf, const uint8_t* src, uint32_t size) {
 }
 
 void
-Utils_DeserializeBlobLE(const uint8_t* buf, uint8_t* dst, uint32_t size) {
+Utils_DeserializeBlobLE(const byte_t* buf, byte_t* dst, uint32_t size) {
     int32_t  j = 0;
     for (int32_t i = ((int32_t)size - 1); i >= 0; --i) {
         dst[j] = buf[i];
@@ -176,7 +176,7 @@ Utils_DeserializeBlobLE(const uint8_t* buf, uint8_t* dst, uint32_t size) {
 }
 
 void
-Utils_Deserialize32BE(const uint8_t* buf, uint32_t* value) {
+Utils_Deserialize32BE(const byte_t* buf, uint32_t* value) {
     *value = (uint32_t)buf[0] << 24u;
     *value |= (uint32_t)buf[1] << 16u;
     *value |= (uint32_t)buf[2] << 8u;
@@ -184,19 +184,19 @@ Utils_Deserialize32BE(const uint8_t* buf, uint32_t* value) {
 }
 
 void
-Utils_Deserialize24BE(const uint8_t* buf, uint32_t* value) {
+Utils_Deserialize24BE(const byte_t* buf, uint32_t* value) {
     *value = (uint32_t)buf[0] << 16u;
     *value |= (uint32_t)buf[1] << 8u;
     *value |= (uint32_t)buf[2];
 }
 
 void
-Utils_Deserialize16BE(const uint8_t* buf, uint16_t* value) {
+Utils_Deserialize16BE(const byte_t* buf, uint16_t* value) {
     *value = (uint16_t)buf[0] << 8U;
     *value |= (uint16_t)buf[1];
 }
 
 void
-Utils_Deserialize8BE(const uint8_t* buf, uint8_t* value) {
+Utils_Deserialize8BE(const byte_t* buf, uint8_t* value) {
     *value = buf[0];
 }

--- a/Tests/test_bubble_sort.c
+++ b/Tests/test_bubble_sort.c
@@ -22,7 +22,7 @@ TEST_GROUP_RUNNER(BubbleSort) {
 TEST(BubbleSort, BubbleSort_int32) {
     int32_t unsorted_array[] = {5, 2, 3, 1000000, 9, 10, 11, 8, 9, 100};
     const int32_t sorted_array[] = {2, 3, 5, 8, 9, 9, 10, 11, 100, 1000000};
-    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+    BubbleSort_sort((byte_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
                     CompareInt32);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
@@ -33,7 +33,7 @@ TEST(BubbleSort, BubbleSort_int32) {
 TEST(BubbleSort, BubbleSort_float64) {
     float64_t unsorted_array[] = {5.8, 2.2, 3.1, 1.1, 9.1, 10.3, 11.2, 8.4, 9.2, 100.9};
     const float64_t sorted_array[] = {1.1, 2.2, 3.1, 5.8, 8.4, 9.1, 9.2, 10.3, 11.2, 100.9};
-    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+    BubbleSort_sort((byte_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
                     CompareFloat64);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
@@ -44,7 +44,7 @@ TEST(BubbleSort, BubbleSort_float64) {
 TEST(BubbleSort, BubbleSort_uint64) {
     uint64_t unsorted_array[] = {1111111U, 55555555U, 44444U, 10000000000000U, 212121U, 1111U, 1U, 2U, 5U, 3U};
     const uint64_t sorted_array[] = {1U, 2U, 3U, 5U, 1111U, 44444U, 212121U, 1111111U, 55555555U, 10000000000000U};
-    BubbleSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+    BubbleSort_sort((byte_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
                     CompareUint64);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {

--- a/Tests/test_heap_sort.c
+++ b/Tests/test_heap_sort.c
@@ -22,7 +22,7 @@ TEST_GROUP_RUNNER(HeapSort) {
 TEST(HeapSort, HeapSort_int32) {
     int32_t unsorted_array[] = {5, 2, 3, 1000000, 9, 10, 11, 8, 9, 100};
     const int32_t sorted_array[] = {2, 3, 5, 8, 9, 9, 10, 11, 100, 1000000};
-    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+    HeapSort_sort((byte_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
                   CompareInt32);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
@@ -33,7 +33,7 @@ TEST(HeapSort, HeapSort_int32) {
 TEST(HeapSort, HeapSort_float64) {
     float64_t unsorted_array[] = {5.8, 2.2, 3.1, 1.1, 9.1, 10.3, 11.2, 8.4, 9.2, 100.9};
     const float64_t sorted_array[] = {1.1, 2.2, 3.1, 5.8, 8.4, 9.1, 9.2, 10.3, 11.2, 100.9};
-    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+    HeapSort_sort((byte_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
                   CompareFloat64);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {
@@ -44,7 +44,7 @@ TEST(HeapSort, HeapSort_float64) {
 TEST(HeapSort, HeapSort_uint64) {
     uint64_t unsorted_array[] = {1111111U, 55555555U, 44444U, 10000000000000U, 212121U, 1111U, 1U, 2U, 5U, 3U};
     const uint64_t sorted_array[] = {1U, 2U, 3U, 5U, 1111U, 44444U, 212121U, 1111111U, 55555555U, 10000000000000U};
-    HeapSort_sort((uint8_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
+    HeapSort_sort((byte_t*)unsorted_array, sizeof(unsorted_array) / sizeof(unsorted_array[0]), sizeof(unsorted_array[0]),
                   CompareUint64);
 
     for (uint32_t i = 0U; i < (sizeof(unsorted_array) / sizeof(unsorted_array[0])); ++i) {

--- a/Tests/test_utils.c
+++ b/Tests/test_utils.c
@@ -7,7 +7,7 @@
 
 TEST_GROUP(Utils);
 
-static const uint8_t test_data_1[] = {
+static const byte_t test_data_1[] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
     0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29,
@@ -99,14 +99,14 @@ TEST(Utils, Utils_SwapElements) {
     {
         int a = 3;
         int b = 4;
-        Utils_SwapElements((uint8_t*)&a, (uint8_t*)&b, sizeof(int));
+        Utils_SwapElements((byte_t*)&a, (byte_t*)&b, sizeof(int));
         TEST_ASSERT_EQUAL_INT(a, 4);
         TEST_ASSERT_EQUAL_INT(b, 3);
     }
     {
         double a = 3.1;
         double b = 4.2;
-        Utils_SwapElements((uint8_t*)&a, (uint8_t*)&b, sizeof(double));
+        Utils_SwapElements((byte_t*)&a, (byte_t*)&b, sizeof(double));
         TEST_ASSERT_EQUAL_DOUBLE(a, 4.2);
         TEST_ASSERT_EQUAL_DOUBLE(b, 3.1);
     }
@@ -114,7 +114,7 @@ TEST(Utils, Utils_SwapElements) {
 
 TEST(Utils, Utils_SerializeBlobBE) {
     const size_t size = 50;
-    uint8_t result_data[size];
+    byte_t result_data[size];
     Utils_SerializeBlobBE(result_data, test_data_1, size);
 
     for (uint32_t i = 0; i < size; ++i) {
@@ -123,7 +123,7 @@ TEST(Utils, Utils_SerializeBlobBE) {
 }
 
 TEST(Utils, Utils_Serialize32BE) {
-    uint8_t buffer[10];
+    byte_t buffer[10];
     uint32_t value1 = 0x11223344U;
     uint32_t value2 = 0x55667788U;
     Utils_Serialize32BE(&buffer[0], value1);
@@ -140,7 +140,7 @@ TEST(Utils, Utils_Serialize32BE) {
 }
 
 TEST(Utils, Utils_Serialize24BE) {
-    uint8_t buffer[10];
+    byte_t buffer[10];
     uint32_t value1 = (0x00FFFFFFU & 0x112233U);
     uint32_t value2 = (0x00FFFFFFU & 0x445566U);
     Utils_Serialize24BE(&buffer[0], value1);
@@ -155,7 +155,7 @@ TEST(Utils, Utils_Serialize24BE) {
 }
 
 TEST(Utils, Utils_Serialize16BE) {
-    uint8_t buffer[10];
+    byte_t buffer[10];
     uint16_t value1 = 0x1122U;
     uint16_t value2 = 0x3344U;
     Utils_Serialize16BE(&buffer[0], value1);
@@ -168,7 +168,7 @@ TEST(Utils, Utils_Serialize16BE) {
 }
 
 TEST(Utils, Utils_Serialize8BE) {
-    uint8_t buffer[10];
+    byte_t buffer[10];
     uint8_t value1 = 0x11U;
     uint8_t value2 = 0x22U;
     uint8_t value3 = 0x33U;
@@ -186,7 +186,7 @@ TEST(Utils, Utils_Serialize8BE) {
 
 TEST(Utils, Utils_DeserializeBlobBE) {
     const size_t size = 50;
-    uint8_t result_data[size];
+    byte_t result_data[size];
     Utils_DeserializeBlobBE(test_data_1, result_data, size);
 
     for (uint32_t i = 0; i < size; ++i) {
@@ -242,7 +242,7 @@ TEST(Utils, Utils_Deserialize8BE) {
 
 TEST(Utils, Utils_SerializeBlobLE) {
     const size_t size = 50;
-    uint8_t result_data[size];
+    byte_t result_data[size];
     Utils_SerializeBlobLE(result_data, test_data_1, size);
 
     for (uint32_t i = 0, j = (size - 1); i < size; ++i, --j) {
@@ -252,7 +252,7 @@ TEST(Utils, Utils_SerializeBlobLE) {
 
 TEST(Utils, Utils_DeserializeBlobLE) {
     const size_t size = 50;
-    uint8_t result_data[size];
+    byte_t result_data[size];
     Utils_DeserializeBlobLE(test_data_1, result_data, size);
 
     for (uint32_t i = 0, j = (size - 1); i < size; ++i, --j) {
@@ -262,8 +262,8 @@ TEST(Utils, Utils_DeserializeBlobLE) {
 
 TEST(Utils, Utils_BigEndianSerializeDeserialize) {
     const size_t size = 50;
-    uint8_t result_data_serialize[size];
-    uint8_t result_data_deserialize[size];
+    byte_t result_data_serialize[size];
+    byte_t result_data_deserialize[size];
     Utils_SerializeBlobBE(result_data_serialize, test_data_1, size);
     Utils_DeserializeBlobBE(result_data_serialize, result_data_deserialize, size);
 
@@ -274,8 +274,8 @@ TEST(Utils, Utils_BigEndianSerializeDeserialize) {
 
 TEST(Utils, Utils_LittleEndianSerializeDeserialize) {
     const size_t size = 50;
-    uint8_t result_data_serialize[size];
-    uint8_t result_data_deserialize[size];
+    byte_t result_data_serialize[size];
+    byte_t result_data_deserialize[size];
     Utils_SerializeBlobLE(result_data_serialize, test_data_1, size);
     Utils_DeserializeBlobLE(result_data_serialize, result_data_deserialize, size);
 


### PR DESCRIPTION
Updated in the code everywhere where I notice we are passing pointers to buffers that we can have possible issues with aliasing. 