### PR TITLE
Add codecov, move build files in build folder, remove make gcov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "Tests"  # ignore Tests folder 

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,7 +3,7 @@ name: Unit tests
 on:
   push:
     branches: 
-    - 'main'
+    - '*'
   pull_request:
     branches:
     - '*'
@@ -30,3 +30,8 @@ jobs:
       
     - name: make ${{matrix.config}}
       run: make ${{matrix.config}}
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        gcov: true

--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ C_DEFS += \
 -DGIT_HASH=\"$(HASH)\" \
 -DGIT_TAG=\"$(TAG)\"
 
-TARGET_BASE1=all_tests
-TARGET1 = $(TARGET_BASE1)$(TARGET_EXTENSION)
-SRC_FILES=\
-  $(UNITY_ROOT)/src/unity.c \
-  $(UNITY_ROOT)/extras/fixture/src/unity_fixture.c \
+TARGET_DIR=build
+TARGET_BASE=all_tests
+TARGET = $(TARGET_DIR)/$(TARGET_BASE)$(TARGET_EXTENSION)
+
+IMUTILITY_FILES=\
   Src/base64.c \
   Src/bubble_sort.c \
   Src/crc32.c \
@@ -63,7 +63,11 @@ SRC_FILES=\
   Src/priority_queue.c \
   Src/queue.c \
   Src/scheduler.c \
-  Src/utils.c \
+  Src/utils.c
+
+SRC_FILES+=$(IMUTILITY_FILES) \
+  $(UNITY_ROOT)/src/unity.c \
+  $(UNITY_ROOT)/extras/fixture/src/unity_fixture.c \
   Tests/Helper/sort_functions.c \
   Tests/test_main.c \
   Tests/test_base64.c \
@@ -113,27 +117,14 @@ misra:
 GCOV_EXTENSIONS=*.gc*
 GCOVR_FOLDER=gcovr-report
 LCOV_FOLDER=lcov-report
-GCOV_FILES=\
-  base64.c \
-  bubble_sort.c \
-  crc32.c \
-  heap_sort.c \
-  json.c \
-  priority_queue.c \
-  queue.c \
-  scheduler.c \
-  utils.c \
 
-gcov:
-	gcov $(GCOV_FILES)
-
-lcov-report: gcov
+lcov-report: all
 	mkdir $(LCOV_FOLDER)
 	lcov --capture --directory . --output-file $(LCOV_FOLDER)/coverage.info
 	lcov --remove $(LCOV_FOLDER)/coverage.info '*/Tests/*' --output-file $(LCOV_FOLDER)/coverage.info
 	genhtml $(LCOV_FOLDER)/coverage.info --output-directory $(LCOV_FOLDER)
 
-gcovr-report: gcov
+gcovr-report: all
 	mkdir $(GCOVR_FOLDER)
 	gcovr -e "Tests" --root . --html --html-details --output $(GCOVR_FOLDER)/coverage.html
 
@@ -141,7 +132,7 @@ gcovr-report: gcov
 # Dependancies
 #######################################
 deps:
-	sudo apt-get install lcov clang-format
+	sudo apt-get install lcov
 	pip3 install gcovr
 
 #######################################
@@ -151,12 +142,13 @@ deps:
 all: clean default
 
 default:
-	$(C_COMPILER) $(CFLAGS) $(C_DEFS) $(INC_DIRS) $(SYMBOLS) -g $(SRC_FILES) -o $(TARGET1) -lm
-	- ./$(TARGET1) -v 
+	mkdir $(TARGET_DIR)
+	$(C_COMPILER) $(CFLAGS) $(C_DEFS) $(INC_DIRS) $(SYMBOLS) -g $(SRC_FILES) -o $(TARGET) -lm
+	- ./$(TARGET) -v 
 
 clean:
-	$(CLEANUP) $(TARGET1) $(GCOV_EXTENSIONS) \
-	rmdir -rf $(GCOVR_FOLDER) $(LCOV_FOLDER)
+	$(CLEANUP) $(TARGET) $(GCOV_EXTENSIONS) \
+	rmdir -rf $(TARGET_DIR) $(GCOVR_FOLDER) $(LCOV_FOLDER)
 
 ci: CFLAGS += -Werror
 ci: default

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 [![Discord Shield](https://discordapp.com/api/guilds/1059535033347604560/widget.png?style=shield)](https://discord.gg/R6nZxZqDH3)
 [![Build](https://github.com/IMProject/IMUtility/actions/workflows/compile.yml/badge.svg)](https://github.com/IMProject/IMUtility/actions/workflows/compile.yml?query=branch%3Amain) [![Build](https://github.com/IMProject/IMUtility/actions/workflows/checks.yml/badge.svg)](https://github.com/IMProject/IMUtility/actions/workflows/checks.yml?query=branch%3Amain)
+[![codecov](https://codecov.io/github/IMProject/IMUtility/branch/main/graph/badge.svg?token=XF771QJZ1G)](https://codecov.io/github/IMProject/IMUtility)
 
 
 # IMUtility: A Safety-Critical Utility Code for C


### PR DESCRIPTION
- Added a build folder for artifacts created by the build process
- Removed `make gcov` since it doesn't seems it has a purpose in generating gcovr and lcov reports
- added codecov, which is helpful for GitHub to get coverage