### PR TITLE
100% Utils_StringToUint32 coverage, fix and description

### DIFF
--- a/Inc/utils.h
+++ b/Inc/utils.h
@@ -38,6 +38,22 @@
 #include "typedefs.h"
 
 bool Utils_QuickUint32Pow10(const uint8_t exponent, uint32_t* result);
+
+/**
+ * @brief Converts a string to an unsigned 32-bit integer.
+ *
+ * This function converts a string to an unsigned 32-bit integer. The string does not need
+ * to be null-terminated and requires the string length to be provided. The function returns
+ * a boolean value indicating the success of the conversion and stores the converted integer
+ * in the provided integer pointer.
+ *
+ * @param[in] str Pointer to the string to convert.
+   @param[in] str_length Length of the string.
+   @param[out] integer Pointer to store the converted unsigned 32-bit integer.
+
+   @return true if the conversion was successful, false otherwise.
+ */
+
 bool Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* integer);
 void Utils_SwapElements(byte_t* first, byte_t* second, const uint32_t size);
 

--- a/Src/utils.c
+++ b/Src/utils.c
@@ -66,7 +66,7 @@ Utils_StringToUint32(const char* str, const uint8_t str_length, uint32_t* intege
         length = str_length - 1U;
     }
 
-    while ((length > i) && (str[i] != '\0') && success) {
+    while ((length > i) && success) {
 
         if ((str[i] >= '0') && (str[i] <= '9')) {
 

--- a/Tests/test_utils.c
+++ b/Tests/test_utils.c
@@ -93,6 +93,22 @@ TEST(Utils, Utils_StringToUint32) {
 
     char not_a_number_4_string[] = "429496729A";
     TEST_ASSERT_FALSE(Utils_StringToUint32(not_a_number_4_string, strlen(not_a_number_4_string), &ui32_number));
+
+    char number_string_edge_case_1[] = "/";
+    TEST_ASSERT_FALSE(Utils_StringToUint32(number_string_edge_case_1, strlen(number_string_edge_case_1), &ui32_number));
+
+    char number_string_edge_case_2[] = ":";
+    TEST_ASSERT_FALSE(Utils_StringToUint32(number_string_edge_case_2, strlen(number_string_edge_case_2), &ui32_number));
+
+    const uint8_t force_overflow_check_size = 10U;
+    char number_string_edge_case_3[10U] = "12345A";
+    TEST_ASSERT_FALSE(Utils_StringToUint32(number_string_edge_case_3, force_overflow_check_size, &ui32_number));
+
+    char number_string_edge_case_4[] = "123456789/";
+    TEST_ASSERT_FALSE(Utils_StringToUint32(number_string_edge_case_4, strlen(number_string_edge_case_4), &ui32_number));
+
+    char number_string_edge_case_5[] = "123456789:";
+    TEST_ASSERT_FALSE(Utils_StringToUint32(number_string_edge_case_5, strlen(number_string_edge_case_5), &ui32_number));
 }
 
 TEST(Utils, Utils_SwapElements) {


### PR DESCRIPTION
An issue was found in Utils_StringToUint32 during testing where it expected null-terminated characters, despite the function being intended to work with string length. The discovery of this problem was made possible through code coverage analysis, demonstrating the crucial role of good code coverage in identifying potential issues and improving code quality.